### PR TITLE
fix(贴图): 修复原生命令运行时失败时无法回退到 WebView 版的问题

### DIFF
--- a/src/plugins/context_menu/contextMenu.js
+++ b/src/plugins/context_menu/contextMenu.js
@@ -133,13 +133,11 @@ class PreviewController {
             filePath: item.previewImage,
           });
         } catch (nativeError) {
-          const message = nativeError?.toString?.() ?? "";
-          if (message.includes("not found") || message.includes("Command")) {
-            invoke("pin_image_from_file", {
-              filePath: item.previewImage,
-              previewMode: true,
-            }).catch(() => {});
-          }
+          console.error("原生预览失败，回退到 Tauri WebView 版:", nativeError);
+          invoke("pin_image_from_file", {
+            filePath: item.previewImage,
+            previewMode: true,
+          }).catch((fallbackError) => { console.error("WebView 预览也失败:", fallbackError); });
         }
       }, LAYOUT.previewDelay);
       this.timers.set(menuItem, timer);

--- a/src/shared/api/clipboard.js
+++ b/src/shared/api/clipboard.js
@@ -163,17 +163,15 @@ export async function pinImageToScreen(filePath) {
     await invoke('create_native_pin_from_file', { filePath })
     return true
   } catch (error) {
-    if (error?.toString?.()?.includes('not found') || error?.toString?.()?.includes('Command')) {
-      try {
-        await invoke('pin_image_from_file', { filePath })
-        return true
-      } catch (fallbackError) {
-        console.error('tauri版也失败:', fallbackError)
-        throw fallbackError
-      }
+    console.error('原生贴图失败，回退到 Tauri WebView 版:', error)
+    try {
+      await invoke('pin_image_from_file', { filePath })
+      return true
+    } catch (fallbackError) {
+      console.error('贴图到屏幕失败（原生版和Tauri版均失败）:', error, fallbackError)
+      const combinedError = new Error(`贴图到屏幕失败: 原生版 - ${error?.message || error}; Tauri WebView 版 - ${fallbackError?.message || fallbackError}`)
+      throw combinedError
     }
-    console.error('贴图到屏幕失败:', error)
-    throw error
   }
 }
 

--- a/src/shared/utils/contextMenu.js
+++ b/src/shared/utils/contextMenu.js
@@ -475,8 +475,13 @@ async function handleContentTypeActions(result, item, index) {
   const actions = {
     "add-to-transfer-shelf": async () => {},
     "pin-image": async () => {
-      await pinImageToScreen(filePath);
-      toast.success(i18n.t("contextMenu.imagePinned"), TOAST_CONFIG);
+      try {
+        await pinImageToScreen(filePath);
+        toast.success(i18n.t("contextMenu.imagePinned"), TOAST_CONFIG);
+      } catch (error) {
+        console.error("贴图到屏幕失败:", error);
+        toast.error(i18n.t("common.operationFailed"), TOAST_CONFIG);
+      }
     },
     "save-image": async () => {
       await saveImageFromPath(filePath);


### PR DESCRIPTION
## 摘要

修复前端原生 GPU 图像功能的回退逻辑缺陷：去除基于错误字符串匹配的条件判断，改为无条件回退。
虽然只是健壮性修复（实际连回退逻辑都没触发就是了（
## 问题描述

v0.4.0 官方发行版中，贴图功能无法调用。入口（右键菜单「贴到屏幕」、托盘菜单「贴图」）均无响应，无窗口弹出，无错误提示。

## 分析

实际测试中发现完整链路存在两层问题。

### 第一层：gpu-image-viewer 侧窗口不可见但未报错

完整版中调用贴图功能，前端收到成功返回值，`toast.success` 提示「图片已贴到屏幕」，但实际没有贴图窗口出现。此时前端未进入 `catch` 分支，回退逻辑未触发。

### 第二层：前端回退逻辑只匹配特定错误字符串

`clipboard.js:pinImageToScreen()` 和 `contextMenu.js:PreviewController.bind()` 中的回退条件：

```js
if (error?.toString?.()?.includes('not found') || error?.toString?.()?.includes('Command')) {
    // 回退到 Tauri WebView 版
}
```

此条件只命中「命令未注册」场景（社区编译版），未命中「命令已注册但运行时失败」场景（官方发行版）：

| 版本 | 命令状态 | invoke 抛出的错误 | 回退触发 |
|---|---|---|---|
| 社区编译版 | 未注册 | `"Command ... not found"` | ✅ |
| 官方发行版 | 已注册，GPU 运行时失败 | `"创建原生贴图窗口失败: WebGPU adapter not available"` | ❌ |
| 官方发行版 | 已注册，驱动兼容性失败 | `"GPU adapter initialization failed: DXGI_ERROR_DEVICE_REMOVED"` | ❌ |

官方发行版中 `gpu-image-viewer` 插件已编译进应用，`create_native_pin_from_file` / `show_native_image_preview` 命令已注册。运行时失败时 Rust 命令返回的 `Err(String)` 不包含 `"not found"` 或 `"Command"` 关键词，回退条件不满足，`pin_image_from_file` 永远不会被调用。

Rust 侧 `src-tauri/src/windows/tray/menu.rs:272-283` 在同一提交（`d95a542e`）中已实现无条件回退（`if let Err(e) = create_native_pin_from_file(…) { eprintln!(…); fallback }`），前端两处是此一致模式的仅剩遗留。

### 两层问题叠加

| 场景 | 第一层 | 第二层 | 结果 |
|---|---|---|---|
| 窗口不可见但未报错 | 前端未进入 catch | 回退不触发 | ❌ 无窗口，无提示 |
| 命令抛错 | 进入 catch | 字符串匹配失败 | ❌ 报错但无回退 |
| 社区版（命令未注册） | 进入 catch | 字符串匹配成功 | ✅ 回退正常 |

本 PR 修复第二层。

## 复现方法

社区版原生命令不存在，无法直接复现。在前端注入 mock 错误模拟 GPU 运行时失败：

```js
// clipboard.js - pinImageToScreen()
throw new Error('GPU adapter initialization failed: DXGI_ERROR_DEVICE_REMOVED')

// contextMenu.js - PreviewController.bind()
throw new Error('GPU adapter initialization failed: DXGI_ERROR_DEVICE_REMOVED')
```

错误不含 `"not found"` 或 `"Command"`。

## 复现结果

| 测试项 | 未修复版（含 mock） | 修复版 |
|---|---|---|
| 右键菜单「贴到屏幕」 | ❌ 报错，无窗口弹出 | ✅ 回退到 WebView 版，正常贴图 |
| 托盘菜单「贴图」 | ❌ 报错 | ✅ 回退正常 |
| 右键菜单图片预览 | ❌ 无预览弹出 | ✅ 回退到 WebView 预览 |

## 修改文件

- `src/shared/api/clipboard.js` — `pinImageToScreen()` 回退逻辑，补日志，双重失败时合并错误信息
- `src/plugins/context_menu/contextMenu.js` — `PreviewController.bind()` 预览回退逻辑，WebView 版失败时补日志
- `src/shared/utils/contextMenu.js` — `handleContentTypeActions()` 调用方加 try/catch + toast.error

## 验证

- 社区编译版：贴图和预览回退到 Tauri WebView 版，行为不变
- Mock GPU failure：3 个入口均正常回退，双重失败时用户收到 toast 错误提示
- `git grep` 确认错误字符串匹配模式（`includes('not found') || includes('Command')`）已从 JS 代码库完全消除
