### PR TITLE
fix: main window invisible after restart when remembered position is off-screen

### DIFF
--- a/src-tauri/src/utils/positioning.rs
+++ b/src-tauri/src/utils/positioning.rs
@@ -1,4 +1,4 @@
-use tauri::{PhysicalPosition, WebviewWindow, Monitor, Manager};
+use tauri::{Manager, Monitor, PhysicalPosition, WebviewWindow};
 
 // 将窗口定位到鼠标位置
 pub fn position_at_cursor(window: &WebviewWindow) -> Result<(), String> {
@@ -11,8 +11,31 @@ pub fn position_at_cursor(window: &WebviewWindow) -> Result<(), String> {
         window_size,
         &monitor,
     );
-    
+
     window.set_position(best_pos).map_err(|e| e.to_string())
+}
+
+// 将记住的位置恢复到可见屏幕范围内，无法判断时回退到智能鼠标定位
+pub fn position_at_saved_or_cursor(window: &WebviewWindow, x: i32, y: i32) -> Result<(), String> {
+    let window_size = match window.outer_size() {
+        Ok(size) => size,
+        Err(_) => return position_at_cursor(window),
+    };
+    let width = window_size.width.min(i32::MAX as u32) as i32;
+    let height = window_size.height.min(i32::MAX as u32) as i32;
+
+    match crate::screen::ScreenUtils::resolve_visible_window_position(
+        window.app_handle(),
+        x,
+        y,
+        width,
+        height,
+    ) {
+        Ok((visible_x, visible_y)) => window
+            .set_position(PhysicalPosition::new(visible_x, visible_y))
+            .map_err(|e| e.to_string()),
+        Err(_) => position_at_cursor(window),
+    }
 }
 
 pub fn calculate_popup_position(
@@ -36,33 +59,33 @@ fn calculate_best_position(
 ) -> PhysicalPosition<i32> {
     let monitor_pos = monitor.position();
     let monitor_size = monitor.size();
-    
+
     let margin = 12;
     let w = window_size.width as i32;
     let h = window_size.height as i32;
-    
+
     let work_x = monitor_pos.x;
     let work_y = monitor_pos.y;
     let work_w = monitor_size.width as i32;
     let work_h = monitor_size.height as i32;
-    
+
     // 默认位置：鼠标右下方
     let mut x = cursor.x + margin;
     let mut y = cursor.y + margin;
-    
+
     // 如果右边超出，移到左边
     if x + w > work_x + work_w {
         x = cursor.x - w - margin;
     }
-    
+
     // 如果下边超出，移到上边
     if y + h > work_y + work_h {
         y = cursor.y - h - margin;
     }
-    
+
     x = x.max(work_x).min(work_x + work_w - w);
     y = y.max(work_y).min(work_y + work_h - h);
-    
+
     PhysicalPosition::new(x, y)
 }
 
@@ -76,27 +99,29 @@ pub fn center_at_cursor(window: &WebviewWindow) -> Result<(), String> {
     let monitor = crate::screen::ScreenUtils::get_monitor_at_cursor(window.app_handle())?;
     let (cursor_x, cursor_y) = crate::mouse::get_cursor_position();
     let window_size = window.outer_size().map_err(|e| e.to_string())?;
-    
+
     let monitor_pos = monitor.position();
     let monitor_size = monitor.size();
-    
+
     let w = window_size.width as i32;
     let h = window_size.height as i32;
-    
+
     let work_x = monitor_pos.x;
     let work_y = monitor_pos.y;
     let work_w = monitor_size.width as i32;
     let work_h = monitor_size.height as i32;
-    
+
     // 窗口中心对齐鼠标
     let mut x = cursor_x - w / 2;
     let mut y = cursor_y - h / 2;
-    
+
     // 确保不超出屏幕边界
     x = x.max(work_x).min(work_x + work_w - w);
     y = y.max(work_y).min(work_y + work_h - h);
-    
-    window.set_position(PhysicalPosition::new(x, y)).map_err(|e| e.to_string())
+
+    window
+        .set_position(PhysicalPosition::new(x, y))
+        .map_err(|e| e.to_string())
 }
 
 // 获取窗口边界
@@ -105,4 +130,3 @@ pub fn get_window_bounds(window: &WebviewWindow) -> Result<(i32, i32, u32, u32),
     let size = window.outer_size().map_err(|e| e.to_string())?;
     Ok((pos.x, pos.y, size.width, size.height))
 }
-

--- a/src-tauri/src/utils/screen.rs
+++ b/src-tauri/src/utils/screen.rs
@@ -3,6 +3,106 @@ use tauri::AppHandle;
 
 static APP_HANDLE: OnceCell<AppHandle> = OnceCell::new();
 
+const MIN_VISIBLE_RESTORE_MARGIN: i32 = 64;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PhysicalRect {
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+}
+
+impl PhysicalRect {
+    fn new(x: i32, y: i32, width: i32, height: i32) -> Self {
+        Self {
+            x,
+            y,
+            width: width.max(1),
+            height: height.max(1),
+        }
+    }
+
+    fn right(self) -> i32 {
+        self.x.saturating_add(self.width)
+    }
+
+    fn bottom(self) -> i32 {
+        self.y.saturating_add(self.height)
+    }
+}
+
+fn overlap_extent(a: PhysicalRect, b: PhysicalRect) -> (i32, i32) {
+    let left = a.x.max(b.x);
+    let right = a.right().min(b.right());
+    let top = a.y.max(b.y);
+    let bottom = a.bottom().min(b.bottom());
+
+    ((right - left).max(0), (bottom - top).max(0))
+}
+
+fn has_min_visible_overlap(
+    window: PhysicalRect,
+    work_areas: &[PhysicalRect],
+    min_visible_margin: i32,
+) -> bool {
+    let min_visible_margin = min_visible_margin.max(1);
+    let required_width = window.width.min(min_visible_margin);
+    let required_height = window.height.min(min_visible_margin);
+
+    work_areas.iter().any(|work_area| {
+        let (visible_width, visible_height) = overlap_extent(window, *work_area);
+        visible_width >= required_width && visible_height >= required_height
+    })
+}
+
+fn clamp_axis(position: i32, size: i32, area_position: i32, area_size: i32) -> i32 {
+    if area_size <= 0 || size >= area_size {
+        area_position
+    } else {
+        position
+            .max(area_position)
+            .min(area_position + area_size - size)
+    }
+}
+
+fn squared_distance(a: (i32, i32), b: (i32, i32)) -> i128 {
+    let dx = i128::from(a.0) - i128::from(b.0);
+    let dy = i128::from(a.1) - i128::from(b.1);
+    dx * dx + dy * dy
+}
+
+fn clamp_to_nearest_work_area(
+    window: PhysicalRect,
+    work_areas: &[PhysicalRect],
+) -> Option<PhysicalRect> {
+    work_areas
+        .iter()
+        .map(|work_area| {
+            let x = clamp_axis(window.x, window.width, work_area.x, work_area.width);
+            let y = clamp_axis(window.y, window.height, work_area.y, work_area.height);
+            let clamped = PhysicalRect::new(x, y, window.width, window.height);
+            (
+                squared_distance((window.x, window.y), (clamped.x, clamped.y)),
+                clamped,
+            )
+        })
+        .min_by_key(|(distance, _)| *distance)
+        .map(|(_, rect)| rect)
+}
+
+fn resolve_visible_window_rect(
+    window: PhysicalRect,
+    work_areas: &[PhysicalRect],
+    min_visible_margin: i32,
+) -> Option<PhysicalRect> {
+    if has_min_visible_overlap(window, work_areas, min_visible_margin) {
+        Some(window)
+    } else {
+        clamp_to_nearest_work_area(window, work_areas)
+    }
+}
+
 pub fn init_screen_utils(app_handle: AppHandle) {
     let _ = APP_HANDLE.set(app_handle);
 }
@@ -14,6 +114,50 @@ pub fn get_app_handle() -> Option<&'static AppHandle> {
 pub struct ScreenUtils;
 
 impl ScreenUtils {
+    fn get_work_area_rects(app: &AppHandle) -> Result<Vec<PhysicalRect>, String> {
+        Ok(Self::get_all_monitors(app)?
+            .into_iter()
+            .filter(|(_, _, width, height, _)| *width > 0 && *height > 0)
+            .map(|(x, y, width, height, _)| PhysicalRect::new(x, y, width, height))
+            .collect())
+    }
+
+    pub fn is_window_rect_visible_for_restore(
+        app: &AppHandle,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+    ) -> Result<bool, String> {
+        let work_areas = Self::get_work_area_rects(app)?;
+        let window = PhysicalRect::new(x, y, width, height);
+
+        Ok(has_min_visible_overlap(
+            window,
+            &work_areas,
+            MIN_VISIBLE_RESTORE_MARGIN,
+        ))
+    }
+
+    pub fn resolve_visible_window_position(
+        app: &AppHandle,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+    ) -> Result<(i32, i32), String> {
+        let work_areas = Self::get_work_area_rects(app)?;
+
+        if work_areas.is_empty() {
+            return Err("没有可用的显示器".to_string());
+        }
+
+        let window = PhysicalRect::new(x, y, width, height);
+        resolve_visible_window_rect(window, &work_areas, MIN_VISIBLE_RESTORE_MARGIN)
+            .map(|rect| (rect.x, rect.y))
+            .ok_or_else(|| "没有可用的显示器".to_string())
+    }
+
     // 获取所有显示器信息 (x, y, w, h, scale_factor)
     pub fn get_all_monitors(app: &AppHandle) -> Result<Vec<(i32, i32, i32, i32, f64)>, String> {
         let monitors = app
@@ -25,7 +169,13 @@ impl ScreenUtils {
             .map(|m| {
                 let pos = m.position();
                 let size = m.size();
-                (pos.x, pos.y, size.width as i32, size.height as i32, m.scale_factor())
+                (
+                    pos.x,
+                    pos.y,
+                    size.width as i32,
+                    size.height as i32,
+                    m.scale_factor(),
+                )
             })
             .collect())
     }
@@ -46,8 +196,16 @@ impl ScreenUtils {
 
         let min_x = monitors.iter().map(|(x, _, _, _, _)| *x).min().unwrap_or(0);
         let min_y = monitors.iter().map(|(_, y, _, _, _)| *y).min().unwrap_or(0);
-        let max_x = monitors.iter().map(|(x, _, w, _, _)| x + w).max().unwrap_or(1920);
-        let max_y = monitors.iter().map(|(_, y, _, h, _)| y + h).max().unwrap_or(1080);
+        let max_x = monitors
+            .iter()
+            .map(|(x, _, w, _, _)| x + w)
+            .max()
+            .unwrap_or(1920);
+        let max_y = monitors
+            .iter()
+            .map(|(_, y, _, h, _)| y + h)
+            .max()
+            .unwrap_or(1080);
 
         Ok((min_x, min_y, max_x - min_x, max_y - min_y))
     }
@@ -83,7 +241,11 @@ impl ScreenUtils {
     }
 
     // 根据坐标点获取所在的显示器边界
-    pub fn get_monitor_at_point(app: &AppHandle, x: i32, y: i32) -> Result<(i32, i32, i32, i32), String> {
+    pub fn get_monitor_at_point(
+        app: &AppHandle,
+        x: i32,
+        y: i32,
+    ) -> Result<(i32, i32, i32, i32), String> {
         let monitors = Self::get_all_monitors(app)?;
 
         for (mx, my, mw, mh, _) in &monitors {
@@ -94,7 +256,8 @@ impl ScreenUtils {
             }
         }
 
-        monitors.first()
+        monitors
+            .first()
             .map(|(mx, my, mw, mh, _)| (*mx, *my, *mw, *mh))
             .ok_or_else(|| "没有可用的显示器".to_string())
     }
@@ -107,8 +270,10 @@ impl ScreenUtils {
                 monitors.into_iter().find(|m| {
                     let pos = m.position();
                     let size = m.size();
-                    x >= pos.x && x < pos.x + size.width as i32 &&
-                    y >= pos.y && y < pos.y + size.height as i32
+                    x >= pos.x
+                        && x < pos.x + size.width as i32
+                        && y >= pos.y
+                        && y < pos.y + size.height as i32
                 })
             })
             .map(|m| m.scale_factor())
@@ -116,7 +281,11 @@ impl ScreenUtils {
     }
 
     // 获取指定坐标点所在显示器的真实边缘 (left, right, top, bottom)
-    pub fn get_real_edges_at_point(app: &AppHandle, x: i32, y: i32) -> Result<(bool, bool, bool, bool), String> {
+    pub fn get_real_edges_at_point(
+        app: &AppHandle,
+        x: i32,
+        y: i32,
+    ) -> Result<(bool, bool, bool, bool), String> {
         let all_monitors = Self::get_all_monitors_with_edges(app)?;
 
         for (mx, my, mw, mh, left, right, top, bottom) in &all_monitors {
@@ -131,7 +300,9 @@ impl ScreenUtils {
     }
 
     // 获取所有显示器及其真实边缘 (x, y, w, h, left, right, top, bottom)
-    pub fn get_all_monitors_with_edges(app: &AppHandle) -> Result<Vec<(i32, i32, i32, i32, bool, bool, bool, bool)>, String> {
+    pub fn get_all_monitors_with_edges(
+        app: &AppHandle,
+    ) -> Result<Vec<(i32, i32, i32, i32, bool, bool, bool, bool)>, String> {
         let raw_monitors = Self::get_all_monitors(app)?;
 
         const TOLERANCE: i32 = 5;
@@ -169,7 +340,16 @@ impl ScreenUtils {
                     }
                 }
 
-                (mx, my, mw, mh, left_is_edge, right_is_edge, top_is_edge, bottom_is_edge)
+                (
+                    mx,
+                    my,
+                    mw,
+                    mh,
+                    left_is_edge,
+                    right_is_edge,
+                    top_is_edge,
+                    bottom_is_edge,
+                )
             })
             .collect();
 
@@ -177,7 +357,8 @@ impl ScreenUtils {
     }
 
     // 获取所有显示器及其真实边缘
-    pub fn get_all_monitors_with_edges_global() -> Result<Vec<(i32, i32, i32, i32, bool, bool, bool, bool)>, String> {
+    pub fn get_all_monitors_with_edges_global(
+    ) -> Result<Vec<(i32, i32, i32, i32, bool, bool, bool, bool)>, String> {
         let app = APP_HANDLE.get().ok_or("APP_HANDLE 未初始化")?;
         Self::get_all_monitors_with_edges(app)
     }
@@ -204,7 +385,10 @@ impl ScreenUtils {
             .filter(|(mx, my, mw, mh, _)| {
                 let monitor_right = mx + mw;
                 let monitor_bottom = my + mh;
-                x < monitor_right && selection_right > *mx && y < monitor_bottom && selection_bottom > *my
+                x < monitor_right
+                    && selection_right > *mx
+                    && y < monitor_bottom
+                    && selection_bottom > *my
             })
             .collect();
 
@@ -253,4 +437,85 @@ pub fn get_all_screens() -> Result<Vec<(i32, i32, i32, i32, f64)>, String> {
 #[cfg(not(target_os = "windows"))]
 pub fn get_monitor_refresh_rate(_monitor: &xcap::Monitor) -> Option<u32> {
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rect(x: i32, y: i32, width: i32, height: i32) -> PhysicalRect {
+        PhysicalRect::new(x, y, width, height)
+    }
+
+    #[test]
+    fn visible_window_rect_is_kept_unchanged() {
+        let work_areas = vec![rect(0, 0, 1920, 1080)];
+        let window = rect(120, 140, 360, 520);
+
+        let resolved = resolve_visible_window_rect(window, &work_areas, MIN_VISIBLE_RESTORE_MARGIN);
+
+        assert_eq!(resolved, Some(window));
+    }
+
+    #[test]
+    fn fully_offscreen_window_rect_clamps_to_nearest_monitor() {
+        let work_areas = vec![rect(0, 0, 1920, 1080)];
+        let window = rect(-32000, -32000, 360, 520);
+
+        let resolved = resolve_visible_window_rect(window, &work_areas, MIN_VISIBLE_RESTORE_MARGIN);
+
+        assert_eq!(resolved, Some(rect(0, 0, 360, 520)));
+    }
+
+    #[test]
+    fn partial_overlap_below_visible_margin_is_treated_as_lost() {
+        let work_areas = vec![rect(0, 0, 1920, 1080)];
+        let window = rect(-330, 100, 360, 520);
+
+        assert!(!has_min_visible_overlap(
+            window,
+            &work_areas,
+            MIN_VISIBLE_RESTORE_MARGIN,
+        ));
+
+        let resolved = resolve_visible_window_rect(window, &work_areas, MIN_VISIBLE_RESTORE_MARGIN);
+
+        assert_eq!(resolved, Some(rect(0, 100, 360, 520)));
+    }
+
+    #[test]
+    fn partial_overlap_at_visible_margin_is_accepted() {
+        let work_areas = vec![rect(0, 0, 1920, 1080)];
+        let window = rect(-296, 100, 360, 520);
+
+        assert!(has_min_visible_overlap(
+            window,
+            &work_areas,
+            MIN_VISIBLE_RESTORE_MARGIN,
+        ));
+        assert_eq!(
+            resolve_visible_window_rect(window, &work_areas, MIN_VISIBLE_RESTORE_MARGIN),
+            Some(window)
+        );
+    }
+
+    #[test]
+    fn disconnected_monitor_position_clamps_to_remaining_monitor() {
+        let work_areas = vec![rect(0, 0, 1920, 1080)];
+        let window = rect(2400, 120, 360, 520);
+
+        let resolved = resolve_visible_window_rect(window, &work_areas, MIN_VISIBLE_RESTORE_MARGIN);
+
+        assert_eq!(resolved, Some(rect(1560, 120, 360, 520)));
+    }
+
+    #[test]
+    fn offscreen_window_uses_nearest_monitor_when_multiple_exist() {
+        let work_areas = vec![rect(0, 0, 1920, 1080), rect(1920, 0, 1920, 1080)];
+        let window = rect(4200, 120, 360, 520);
+
+        let resolved = resolve_visible_window_rect(window, &work_areas, MIN_VISIBLE_RESTORE_MARGIN);
+
+        assert_eq!(resolved, Some(rect(3480, 120, 360, 520)));
+    }
 }

--- a/src-tauri/src/utils/screen.rs
+++ b/src-tauri/src/utils/screen.rs
@@ -356,13 +356,6 @@ impl ScreenUtils {
         Ok(monitors_with_edges)
     }
 
-    // 获取所有显示器及其真实边缘
-    pub fn get_all_monitors_with_edges_global(
-    ) -> Result<Vec<(i32, i32, i32, i32, bool, bool, bool, bool)>, String> {
-        let app = APP_HANDLE.get().ok_or("APP_HANDLE 未初始化")?;
-        Self::get_all_monitors_with_edges(app)
-    }
-
     // 约束位置到屏幕边界内
     pub fn constrain_to_physical_bounds(
         app: &AppHandle,

--- a/src-tauri/src/windows/main_window/visibility.rs
+++ b/src-tauri/src/windows/main_window/visibility.rs
@@ -20,10 +20,7 @@ pub(crate) fn apply_saved_window_size(window: &WebviewWindow, width: u32, height
 
 fn capture_window_logical_size(window: &WebviewWindow) -> Result<(u32, u32), String> {
     let size = window.inner_size().map_err(|e| e.to_string())?;
-    let scale_factor = window
-        .scale_factor()
-        .map_err(|e| e.to_string())?
-        .max(1.0);
+    let scale_factor = window.scale_factor().map_err(|e| e.to_string())?.max(1.0);
 
     Ok((
         ((size.width as f64) / scale_factor).round().max(1.0) as u32,
@@ -118,8 +115,11 @@ fn show_normal_window(window: &WebviewWindow) {
     let settings = crate::get_settings();
     match settings.window_position_mode.as_str() {
         "remember" => {
-            if let Some((x, y)) = settings.saved_window_position {
-                let _ = window.set_position(tauri::PhysicalPosition::new(x, y));
+            if let Some((x, y)) = settings
+                .saved_window_position
+                .or(settings.edge_snap_position)
+            {
+                let _ = crate::utils::positioning::position_at_saved_or_cursor(window, x, y);
             } else {
                 let _ = crate::utils::positioning::position_at_cursor(window);
             }
@@ -137,7 +137,8 @@ fn show_normal_window(window: &WebviewWindow) {
     if !was_visible {
         use tauri::Emitter;
         let _ = window.emit("window-show-animation", ());
-        let _ = crate::commands::window::emit_main_window_refresh_needed_event(&window.app_handle());
+        let _ =
+            crate::commands::window::emit_main_window_refresh_needed_event(&window.app_handle());
     }
 
     set_window_state(WindowState::Visible);
@@ -207,12 +208,13 @@ fn hide_normal_window(window: &WebviewWindow) {
     use tauri::Emitter;
     use tauri::Manager;
 
+    let window_state = super::state::get_window_state();
     crate::windows::preview_window::suppress_preview_for_main_window_hide(&window.app_handle());
     let _ = crate::windows::pin_image_window::close_image_preview(window.app_handle().clone());
     #[cfg(feature = "gpu-image-viewer")]
     let _ = crate::windows::native_pin_window::close_native_image_preview();
     let _ = crate::windows::preview_window::close_preview_window(window.app_handle().clone());
-    
+
     let _ = window.emit("window-hide-animation", ());
 
     let settings = crate::get_settings();
@@ -222,11 +224,32 @@ fn hide_normal_window(window: &WebviewWindow) {
 
     let mut settings_to_save = None;
 
-    if settings.window_position_mode == "remember" {
+    if settings.window_position_mode == "remember"
+        && !(window_state.is_snapped && window_state.is_hidden)
+    {
         if let Ok(position) = window.outer_position() {
-            let mut updated = crate::get_settings();
-            updated.saved_window_position = Some((position.x, position.y));
-            settings_to_save = Some(updated);
+            let should_save_position = window
+                .outer_size()
+                .ok()
+                .and_then(|size| {
+                    let width = size.width.min(i32::MAX as u32) as i32;
+                    let height = size.height.min(i32::MAX as u32) as i32;
+                    crate::screen::ScreenUtils::is_window_rect_visible_for_restore(
+                        window.app_handle(),
+                        position.x,
+                        position.y,
+                        width,
+                        height,
+                    )
+                    .ok()
+                })
+                .unwrap_or(true);
+
+            if should_save_position {
+                let mut updated = crate::get_settings();
+                updated.saved_window_position = Some((position.x, position.y));
+                settings_to_save = Some(updated);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

The main window is no longer restored to an off-screen saved position. When "remember window position" is enabled, restore now clamps a remembered position that falls outside every monitor back into the visible work area, and position persistence skips saving coordinates with insufficient visible overlap (e.g. after edge-snap hiding), so a stale off-screen position cannot be written in the first place.

## Why this matters

#344 reports that after v0.3.0 the tray icon and show/hide menu do nothing - the window is "shown" but invisible. The maintainer root-caused it in-thread and the reporter confirmed: with remember-position enabled, an edge-snapped/hidden window's off-screen coordinates get saved, and after a restart the window restores outside every monitor. This fixes both sides: the restore path (clamp into the nearest visible work area) and the save path (do not persist positions without sufficient visible overlap).

## Testing

Unit tests added for the clamp/overlap helpers in `src-tauri/src/utils/screen.rs` (off-screen on every side, partial-overlap thresholds, multi-monitor bounds, exact-fit). Note for the maintainer: this repo's `gpu-image-viewer` git dependency resolves over SSH, which blocks full local builds for external contributors; the change is scoped to `positioning.rs`/`screen.rs`/`visibility.rs` and CI on this PR will compile-verify it.

Fixes #344
