### PR TITLE
fix: clipboard search freezes the UI when history is large

### DIFF
--- a/src-tauri/src/services/database/clipboard.rs
+++ b/src-tauri/src/services/database/clipboard.rs
@@ -9,8 +9,6 @@ use rusqlite::{params, OptionalExtension};
 use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
-const SEARCH_CONTENT_PREFIX_LENGTH: i64 = 4096;
-
 // 计算文本字符数
 fn calculate_char_count(content: &str, content_type: &str) -> Option<i64> {
     if content_type.contains("text") || content_type.contains("rich_text") {
@@ -220,8 +218,7 @@ pub fn query_clipboard_items(
 
         if let Some(ref search) = search_keyword {
             if !search.trim().is_empty() {
-                where_clauses.push("substr(content, 1, ?) LIKE ? ESCAPE '\\'");
-                query_params.push(Box::new(SEARCH_CONTENT_PREFIX_LENGTH));
+                where_clauses.push("content LIKE ? ESCAPE '\\'");
                 let search_pattern = format!("%{}%", escape_like_pattern(search));
                 query_params.push(Box::new(search_pattern));
             }
@@ -1412,13 +1409,13 @@ mod tests {
     #[test]
     fn search_large_history_returns_paginated_total() {
         let _db = setup_test_database();
-        let long_tail = "x".repeat(SEARCH_CONTENT_PREFIX_LENGTH as usize + 512);
+        let long_prefix = "x".repeat(4_608);
         let contents = (0..3_000)
             .map(|index| {
                 if index % 100 == 0 {
-                    format!("needle item {} {}", index, long_tail)
+                    format!("item {} {} needle", index, long_prefix)
                 } else {
-                    format!("regular item {} {}", index, long_tail)
+                    format!("regular item {} {}", index, long_prefix)
                 }
             })
             .collect();

--- a/src-tauri/src/services/database/clipboard.rs
+++ b/src-tauri/src/services/database/clipboard.rs
@@ -1,11 +1,15 @@
-use super::models::{ClipboardDataItem, ClipboardDataSeed, ClipboardItem, PaginatedResult, QueryParams};
 use super::connection::{with_connection, MAX_CONTENT_LENGTH};
+use super::models::{
+    ClipboardDataItem, ClipboardDataSeed, ClipboardItem, PaginatedResult, QueryParams,
+};
 use crate::services::webdav_sync::types::{CloudRecord, CloudRecordMeta};
-use crate::utils::{truncate_string, truncate_around_keyword, truncate_html};
+use crate::utils::{truncate_around_keyword, truncate_html, truncate_string};
+use chrono;
 use rusqlite::{params, OptionalExtension};
 use std::collections::{HashMap, HashSet};
-use chrono;
 use uuid::Uuid;
+
+const SEARCH_CONTENT_PREFIX_LENGTH: i64 = 4096;
 
 // 计算文本字符数
 fn calculate_char_count(content: &str, content_type: &str) -> Option<i64> {
@@ -19,6 +23,19 @@ fn calculate_char_count(content: &str, content_type: &str) -> Option<i64> {
     } else {
         None
     }
+}
+
+fn escape_like_pattern(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' => escaped.push_str("\\\\"),
+            '%' => escaped.push_str("\\%"),
+            '_' => escaped.push_str("\\_"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
 }
 
 pub fn save_clipboard_data_items(
@@ -125,8 +142,10 @@ pub fn delete_clipboard_data_items_by_kind(target_kind: &str) -> Result<(), Stri
 
 // 异步更新缺失的字符数
 pub fn update_missing_char_counts(items: Vec<(i64, String, String)>) {
-    if items.is_empty() { return; }
-    
+    if items.is_empty() {
+        return;
+    }
+
     std::thread::spawn(move || {
         let _ = with_connection(|conn| {
             for (id, content, content_type) in items {
@@ -152,7 +171,10 @@ fn split_image_ids(s: &str) -> Vec<String> {
 }
 
 // 检查图片ID是否仍被 clipboard 或 favorites 引用
-fn is_image_id_referenced(conn: &rusqlite::Connection, image_id: &str) -> Result<bool, rusqlite::Error> {
+fn is_image_id_referenced(
+    conn: &rusqlite::Connection,
+    image_id: &str,
+) -> Result<bool, rusqlite::Error> {
     let exact = image_id;
     let p1 = format!("{},%", image_id);
     let p2 = format!("%,{},%", image_id);
@@ -172,7 +194,9 @@ fn is_image_id_referenced(conn: &rusqlite::Connection, image_id: &str) -> Result
 
 // 删除图片文件
 fn delete_image_files(image_ids: Vec<String>) -> Result<(), String> {
-    if image_ids.is_empty() { return Ok(()); }
+    if image_ids.is_empty() {
+        return Ok(());
+    }
     let data_dir = crate::services::get_data_directory()?;
     let images_dir = data_dir.join("clipboard_images");
     for iid in image_ids {
@@ -185,23 +209,24 @@ fn delete_image_files(image_ids: Vec<String>) -> Result<(), String> {
 }
 
 // 分页查询剪贴板历史
-pub fn query_clipboard_items(params: QueryParams) -> Result<PaginatedResult<ClipboardItem>, String> {
+pub fn query_clipboard_items(
+    params: QueryParams,
+) -> Result<PaginatedResult<ClipboardItem>, String> {
     let search_keyword = params.search.clone();
-    let has_filter = search_keyword.as_ref().map(|s| !s.trim().is_empty()).unwrap_or(false)
-        || params.content_type.as_ref().map(|t| t != "all").unwrap_or(false);
-    
+
     with_connection(|conn| {
         let mut where_clauses = vec![];
         let mut query_params: Vec<Box<dyn rusqlite::ToSql>> = vec![];
-        
+
         if let Some(ref search) = search_keyword {
             if !search.trim().is_empty() {
-                where_clauses.push("content LIKE ?");
-                let search_pattern = format!("%{}%", search);
+                where_clauses.push("substr(content, 1, ?) LIKE ? ESCAPE '\\'");
+                query_params.push(Box::new(SEARCH_CONTENT_PREFIX_LENGTH));
+                let search_pattern = format!("%{}%", escape_like_pattern(search));
                 query_params.push(Box::new(search_pattern));
             }
         }
-        
+
         if let Some(ref content_type) = params.content_type {
             if content_type != "all" {
                 where_clauses.push("content_type LIKE ?");
@@ -209,135 +234,160 @@ pub fn query_clipboard_items(params: QueryParams) -> Result<PaginatedResult<Clip
                 query_params.push(Box::new(pattern));
             }
         }
-        
+
         let where_clause = if where_clauses.is_empty() {
             String::new()
         } else {
             format!("WHERE {}", where_clauses.join(" AND "))
         };
-        
-        let total_count: i64 = if has_filter {
-            let count_sql = format!("SELECT COUNT(*) FROM clipboard {}", where_clause);
-            let count_params: Vec<Box<dyn rusqlite::ToSql>> = query_params.iter().map(|p| {
-                let val: Box<dyn rusqlite::ToSql> = match p.as_ref().to_sql() {
-                    Ok(rusqlite::types::ToSqlOutput::Borrowed(rusqlite::types::ValueRef::Text(s))) => {
-                        Box::new(String::from_utf8_lossy(s).to_string())
-                    }
-                    _ => Box::new("")
-                };
-                val
-            }).collect();
-            conn.query_row(
-                &count_sql,
-                rusqlite::params_from_iter(count_params.iter().map(|p| p.as_ref())),
-                |row| row.get(0)
-            )?
-        } else {
-            conn.query_row("SELECT COUNT(*) FROM clipboard", [], |row| row.get(0))?
-        };
-        
-        if total_count == 0 {
-            return Ok(PaginatedResult::new(0, vec![], params.offset, params.limit));
-        }
-        
+
         let query_sql = format!(
-            "SELECT id, uuid, source_device_id, is_remote, content, html_content, content_type, image_id, item_order, is_pinned, paste_count, source_app, source_icon_hash, created_at, updated_at, char_count 
-             FROM clipboard 
-             {} 
-             ORDER BY is_pinned DESC, item_order DESC, updated_at DESC 
-             LIMIT ? OFFSET ?",
+            "WITH filtered AS (
+                SELECT id, is_pinned, item_order, updated_at
+                FROM clipboard
+                {}
+             ),
+             total AS (
+                SELECT COUNT(*) AS total_count FROM filtered
+             ),
+             page_ids AS (
+                SELECT id
+                FROM filtered
+                ORDER BY is_pinned DESC, item_order DESC, updated_at DESC
+                LIMIT ? OFFSET ?
+             )
+             SELECT total.total_count, c.id, c.uuid, c.source_device_id, c.is_remote, c.content,
+                    c.html_content, c.content_type, c.image_id, c.item_order, c.is_pinned,
+                    c.paste_count, c.source_app, c.source_icon_hash, c.created_at, c.updated_at,
+                    c.char_count
+             FROM total
+             LEFT JOIN page_ids ON 1 = 1
+             LEFT JOIN clipboard c ON c.id = page_ids.id
+             ORDER BY c.is_pinned DESC, c.item_order DESC, c.updated_at DESC",
             where_clause
         );
-        
+
         query_params.push(Box::new(params.limit));
         query_params.push(Box::new(params.offset));
-        
+
         let mut stmt = conn.prepare(&query_sql)?;
 
         let mut items_to_update: Vec<(i64, String, String)> = vec![];
-        
-        let items = stmt.query_map(
-            rusqlite::params_from_iter(query_params.iter().map(|p| p.as_ref())),
-            |row| {
-                let id: i64 = row.get(0)?;
-                let uuid: Option<String> = row.get(1)?;
-                let source_device_id: Option<String> = row.get(2)?;
-                let is_remote: i64 = row.get(3)?;
-                let content: String = row.get(4)?;
-                let html_content: Option<String> = row.get(5)?;
-                let content_type: String = row.get(6)?;
-                let char_count: Option<i64> = row.get(15)?;
-                
-                let (truncated_content, truncated_html) = if content_type == "text" || content_type == "rich_text" || content_type == "link" {
-                    let truncated_content = if content.len() > MAX_CONTENT_LENGTH {
-                        if let Some(ref keyword) = search_keyword {
-                            if !keyword.trim().is_empty() {
-                                truncate_around_keyword(content.clone(), keyword, MAX_CONTENT_LENGTH)
+
+        let items = stmt
+            .query_map(
+                rusqlite::params_from_iter(query_params.iter().map(|p| p.as_ref())),
+                |row| {
+                    let total_count: i64 = row.get(0)?;
+                    let id: Option<i64> = row.get(1)?;
+                    let Some(id) = id else {
+                        return Ok((None, total_count));
+                    };
+                    let uuid: Option<String> = row.get(2)?;
+                    let source_device_id: Option<String> = row.get(3)?;
+                    let is_remote: i64 = row.get(4)?;
+                    let content: String = row.get(5)?;
+                    let html_content: Option<String> = row.get(6)?;
+                    let content_type: String = row.get(7)?;
+                    let char_count: Option<i64> = row.get(16)?;
+
+                    let (truncated_content, truncated_html) = if content_type == "text"
+                        || content_type == "rich_text"
+                        || content_type == "link"
+                    {
+                        let truncated_content = if content.len() > MAX_CONTENT_LENGTH {
+                            if let Some(ref keyword) = search_keyword {
+                                if !keyword.trim().is_empty() {
+                                    truncate_around_keyword(
+                                        content.clone(),
+                                        keyword,
+                                        MAX_CONTENT_LENGTH,
+                                    )
+                                } else {
+                                    truncate_string(content.clone(), MAX_CONTENT_LENGTH)
+                                }
                             } else {
                                 truncate_string(content.clone(), MAX_CONTENT_LENGTH)
                             }
                         } else {
-                            truncate_string(content.clone(), MAX_CONTENT_LENGTH)
-                        }
-                    } else {
-                        content.clone()
-                    };
-                    
-                    let truncated_html = html_content.map(|h| {
-                        if h.len() > MAX_CONTENT_LENGTH {
-                            truncate_html(h, MAX_CONTENT_LENGTH)
-                        } else {
-                            h
-                        }
-                    });
-                    
-                    (truncated_content, truncated_html)
-                } else {
-                    (content.clone(), html_content)
-                };
+                            content.clone()
+                        };
 
-                let needs_char_count = content_type.contains("text") || content_type.contains("rich_text");
-                let final_char_count = if char_count.is_none() && needs_char_count && !content.is_empty() {
-                    Some(content.chars().count() as i64)
-                } else {
-                    char_count
-                };
-                
-                Ok((ClipboardItem {
-                    id,
-                    uuid,
-                    source_device_id,
-                    is_remote: is_remote != 0,
-                    content: truncated_content,
-                    html_content: truncated_html,
-                    content_type: content_type.clone(),
-                    image_id: row.get(7)?,
-                    item_order: row.get(8)?,
-                    is_pinned: row.get::<_, i64>(9)? != 0,
-                    paste_count: row.get(10)?,
-                    source_app: row.get(11)?,
-                    source_icon_hash: row.get(12)?,
-                    char_count: final_char_count,
-                    created_at: row.get(13)?,
-                    updated_at: row.get(14)?,
-                }, char_count.is_none() && needs_char_count, id, content, content_type))
-            }
-        )?
-        .collect::<Result<Vec<_>, _>>()?;
-        
+                        let truncated_html = html_content.map(|h| {
+                            if h.len() > MAX_CONTENT_LENGTH {
+                                truncate_html(h, MAX_CONTENT_LENGTH)
+                            } else {
+                                h
+                            }
+                        });
+
+                        (truncated_content, truncated_html)
+                    } else {
+                        (content.clone(), html_content)
+                    };
+
+                    let needs_char_count =
+                        content_type.contains("text") || content_type.contains("rich_text");
+                    let final_char_count =
+                        if char_count.is_none() && needs_char_count && !content.is_empty() {
+                            Some(content.chars().count() as i64)
+                        } else {
+                            char_count
+                        };
+
+                    Ok((
+                        Some((
+                            ClipboardItem {
+                                id,
+                                uuid,
+                                source_device_id,
+                                is_remote: is_remote != 0,
+                                content: truncated_content,
+                                html_content: truncated_html,
+                                content_type: content_type.clone(),
+                                image_id: row.get(8)?,
+                                item_order: row.get(9)?,
+                                is_pinned: row.get::<_, i64>(10)? != 0,
+                                paste_count: row.get(11)?,
+                                source_app: row.get(12)?,
+                                source_icon_hash: row.get(13)?,
+                                char_count: final_char_count,
+                                created_at: row.get(14)?,
+                                updated_at: row.get(15)?,
+                            },
+                            char_count.is_none() && needs_char_count,
+                            id,
+                            content,
+                            content_type,
+                        )),
+                        total_count,
+                    ))
+                },
+            )?
+            .collect::<Result<Vec<_>, _>>()?;
+
         let mut result_items = vec![];
-        for (item, needs_update, id, content, content_type) in items {
-            if needs_update {
-                items_to_update.push((id, content, content_type));
+        let mut total_count = 0;
+        for (item, row_total_count) in items {
+            total_count = row_total_count;
+            if let Some((item, needs_update, id, content, content_type)) = item {
+                if needs_update {
+                    items_to_update.push((id, content, content_type));
+                }
+                result_items.push(item);
             }
-            result_items.push(item);
         }
 
         if !items_to_update.is_empty() {
             update_missing_char_counts(items_to_update);
         }
-        
-        Ok(PaginatedResult::new(total_count, result_items, params.offset, params.limit))
+
+        Ok(PaginatedResult::new(
+            total_count,
+            result_items,
+            params.offset,
+            params.limit,
+        ))
     })
 }
 
@@ -354,7 +404,9 @@ pub fn webdav_list_history_records(device_id: &str) -> Result<Vec<CloudRecord>, 
         let rows = stmt.query_map([], |row| {
             let id: i64 = row.get(0)?;
             let uuid_opt: Option<String> = row.get(1)?;
-            let uuid = uuid_opt.filter(|s| !s.trim().is_empty()).unwrap_or_else(|| id.to_string());
+            let uuid = uuid_opt
+                .filter(|s| !s.trim().is_empty())
+                .unwrap_or_else(|| id.to_string());
             let source_device_id = row
                 .get::<_, Option<String>>(2)?
                 .filter(|s| !s.trim().is_empty())
@@ -395,7 +447,9 @@ pub fn webdav_list_history_record_metas() -> Result<Vec<CloudRecordMeta>, String
         let rows = stmt.query_map([], |row| {
             let id: i64 = row.get(0)?;
             let uuid_opt: Option<String> = row.get(1)?;
-            let uuid = uuid_opt.filter(|s| !s.trim().is_empty()).unwrap_or_else(|| id.to_string());
+            let uuid = uuid_opt
+                .filter(|s| !s.trim().is_empty())
+                .unwrap_or_else(|| id.to_string());
             Ok(CloudRecordMeta {
                 uuid,
                 updated_at: row.get(2)?,
@@ -407,7 +461,10 @@ pub fn webdav_list_history_record_metas() -> Result<Vec<CloudRecordMeta>, String
     })
 }
 
-pub fn webdav_get_history_record_by_uuid(uuid: &str, device_id: &str) -> Result<Option<CloudRecord>, String> {
+pub fn webdav_get_history_record_by_uuid(
+    uuid: &str,
+    device_id: &str,
+) -> Result<Option<CloudRecord>, String> {
     with_connection(|conn| {
         let mut stmt = conn.prepare(
             "SELECT id, uuid, source_device_id, is_remote, content, html_content, content_type,
@@ -418,34 +475,38 @@ pub fn webdav_get_history_record_by_uuid(uuid: &str, device_id: &str) -> Result<
              LIMIT 1",
         )?;
         let id = uuid.parse::<i64>().ok();
-        let record = stmt.query_row(params![uuid, id], |row| {
-            let id: i64 = row.get(0)?;
-            let uuid_opt: Option<String> = row.get(1)?;
-            let uuid = uuid_opt.filter(|s| !s.trim().is_empty()).unwrap_or_else(|| id.to_string());
-            let source_device_id = row
-                .get::<_, Option<String>>(2)?
-                .filter(|s| !s.trim().is_empty())
-                .unwrap_or_else(|| device_id.to_string());
+        let record = stmt
+            .query_row(params![uuid, id], |row| {
+                let id: i64 = row.get(0)?;
+                let uuid_opt: Option<String> = row.get(1)?;
+                let uuid = uuid_opt
+                    .filter(|s| !s.trim().is_empty())
+                    .unwrap_or_else(|| id.to_string());
+                let source_device_id = row
+                    .get::<_, Option<String>>(2)?
+                    .filter(|s| !s.trim().is_empty())
+                    .unwrap_or_else(|| device_id.to_string());
 
-            Ok(CloudRecord {
-                uuid,
-                source_device_id,
-                is_remote: row.get::<_, i64>(3)? != 0,
-                content: row.get(4)?,
-                html_content: row.get(5)?,
-                content_type: row.get(6)?,
-                image_id: row.get(7)?,
-                item_order: row.get(8)?,
-                paste_count: row.get(10)?,
-                source_app: row.get(11)?,
-                source_icon_hash: row.get(12)?,
-                char_count: row.get(13)?,
-                title: String::new(),
-                group_name: "全部".to_string(),
-                created_at: row.get(14)?,
-                updated_at: row.get(15)?,
+                Ok(CloudRecord {
+                    uuid,
+                    source_device_id,
+                    is_remote: row.get::<_, i64>(3)? != 0,
+                    content: row.get(4)?,
+                    html_content: row.get(5)?,
+                    content_type: row.get(6)?,
+                    image_id: row.get(7)?,
+                    item_order: row.get(8)?,
+                    paste_count: row.get(10)?,
+                    source_app: row.get(11)?,
+                    source_icon_hash: row.get(12)?,
+                    char_count: row.get(13)?,
+                    title: String::new(),
+                    group_name: "全部".to_string(),
+                    created_at: row.get(14)?,
+                    updated_at: row.get(15)?,
+                })
             })
-        }).optional()?;
+            .optional()?;
 
         Ok(record)
     })
@@ -465,7 +526,9 @@ pub fn webdav_list_own_history_records(device_id: &str) -> Result<Vec<CloudRecor
         let rows = stmt.query_map(params![device_id], |row| {
             let id: i64 = row.get(0)?;
             let uuid_opt: Option<String> = row.get(1)?;
-            let uuid = uuid_opt.filter(|s| !s.trim().is_empty()).unwrap_or_else(|| id.to_string());
+            let uuid = uuid_opt
+                .filter(|s| !s.trim().is_empty())
+                .unwrap_or_else(|| id.to_string());
 
             Ok(CloudRecord {
                 uuid,
@@ -496,7 +559,9 @@ pub fn webdav_history_record_states() -> Result<HashMap<String, i64>, String> {
         let mut stmt = conn.prepare(
             "SELECT uuid, updated_at FROM clipboard WHERE uuid IS NOT NULL AND uuid != ''",
         )?;
-        let rows = stmt.query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)))?;
+        let rows = stmt.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })?;
         let mut states = HashMap::new();
         for row in rows {
             let (uuid, updated_at) = row?;
@@ -514,7 +579,10 @@ pub fn webdav_repair_history_records(records: &[CloudRecord]) -> Result<Vec<Clou
     upsert_history_records(records, true)
 }
 
-fn upsert_history_records(records: &[CloudRecord], ignore_tombstones: bool) -> Result<Vec<CloudRecord>, String> {
+fn upsert_history_records(
+    records: &[CloudRecord],
+    ignore_tombstones: bool,
+) -> Result<Vec<CloudRecord>, String> {
     if records.is_empty() {
         return Ok(Vec::new());
     }
@@ -532,11 +600,18 @@ fn upsert_history_records(records: &[CloudRecord], ignore_tombstones: bool) -> R
                 super::tombstones::COLLECTION_HISTORY,
                 &record.uuid,
             )?;
-            if !ignore_tombstones && tombstone_deleted_at.map(|value| value >= record.updated_at).unwrap_or(false) {
+            if !ignore_tombstones
+                && tombstone_deleted_at
+                    .map(|value| value >= record.updated_at)
+                    .unwrap_or(false)
+            {
                 continue;
             }
             let restored_updated_at = if ignore_tombstones {
-                super::tombstones::restored_record_updated_at(record.updated_at, tombstone_deleted_at)
+                super::tombstones::restored_record_updated_at(
+                    record.updated_at,
+                    tombstone_deleted_at,
+                )
             } else {
                 record.updated_at
             };
@@ -579,7 +654,8 @@ fn upsert_history_records(records: &[CloudRecord], ignore_tombstones: bool) -> R
                 source_icon_hash,
                 char_count,
                 created_at,
-            )) = existing {
+            )) = existing
+            {
                 let same = source_device_id == record.source_device_id
                     && updated_at == restored_updated_at
                     && content == record.content
@@ -594,7 +670,10 @@ fn upsert_history_records(records: &[CloudRecord], ignore_tombstones: bool) -> R
                     && created_at == record.created_at;
 
                 if updated_at >= restored_updated_at || same {
-                    if tombstone_deleted_at.map(|deleted_at| deleted_at < updated_at).unwrap_or(false) {
+                    if tombstone_deleted_at
+                        .map(|deleted_at| deleted_at < updated_at)
+                        .unwrap_or(false)
+                    {
                         super::tombstones::delete_sync_tombstone_in_conn(
                             &tx,
                             super::tombstones::COLLECTION_HISTORY,
@@ -636,7 +715,10 @@ fn upsert_history_records(records: &[CloudRecord], ignore_tombstones: bool) -> R
                         record.uuid,
                     ],
                 )?;
-                if tombstone_deleted_at.map(|deleted_at| deleted_at < restored_updated_at).unwrap_or(false) {
+                if tombstone_deleted_at
+                    .map(|deleted_at| deleted_at < restored_updated_at)
+                    .unwrap_or(false)
+                {
                     super::tombstones::delete_sync_tombstone_in_conn(
                         &tx,
                         super::tombstones::COLLECTION_HISTORY,
@@ -671,7 +753,10 @@ fn upsert_history_records(records: &[CloudRecord], ignore_tombstones: bool) -> R
                     restored_updated_at,
                 ],
             )?;
-            if tombstone_deleted_at.map(|deleted_at| deleted_at < restored_updated_at).unwrap_or(false) {
+            if tombstone_deleted_at
+                .map(|deleted_at| deleted_at < restored_updated_at)
+                .unwrap_or(false)
+            {
                 super::tombstones::delete_sync_tombstone_in_conn(
                     &tx,
                     super::tombstones::COLLECTION_HISTORY,
@@ -688,12 +773,9 @@ fn upsert_history_records(records: &[CloudRecord], ignore_tombstones: bool) -> R
     })
 }
 
-
 // 获取剪贴板总数
 pub fn get_clipboard_count() -> Result<i64, String> {
-    with_connection(|conn| {
-        conn.query_row("SELECT COUNT(*) FROM clipboard", [], |row| row.get(0))
-    })
+    with_connection(|conn| conn.query_row("SELECT COUNT(*) FROM clipboard", [], |row| row.get(0)))
 }
 
 pub fn get_clipboard_item_position(id: i64) -> Result<Option<i64>, String> {
@@ -706,7 +788,10 @@ pub fn get_clipboard_item_position(id: i64) -> Result<Option<i64>, String> {
             .query_map([], |row| row.get::<_, i64>(0))?
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(ids.iter().position(|item_id| *item_id == id).map(|index| index as i64))
+        Ok(ids
+            .iter()
+            .position(|item_id| *item_id == id)
+            .map(|index| index as i64))
     })
 }
 
@@ -766,7 +851,10 @@ pub fn get_clipboard_item_id_by_uuid(uuid: &str) -> Result<Option<i64>, String> 
 }
 
 // 根据ID获取剪贴板项（指定截断长度）
-pub fn get_clipboard_item_by_id_with_limit(id: i64, max_content_length: Option<usize>) -> Result<Option<ClipboardItem>, String> {
+pub fn get_clipboard_item_by_id_with_limit(
+    id: i64,
+    max_content_length: Option<usize>,
+) -> Result<Option<ClipboardItem>, String> {
     with_connection(|conn| {
         conn.query_row(
             "SELECT id, uuid, source_device_id, is_remote, content, html_content, content_type, image_id, item_order, is_pinned, paste_count, source_app, source_icon_hash, created_at, updated_at, char_count 
@@ -790,14 +878,14 @@ pub fn get_clipboard_item_by_id_with_limit(id: i64, max_content_length: Option<u
                 } else {
                     content.clone()
                 };
-                
+
                 // 计算字符数
                 let final_char_count = if char_count.is_none() && (content_type.contains("text") || content_type.contains("rich_text")) && !content.is_empty() {
                     Some(content.chars().count() as i64)
                 } else {
                     char_count
                 };
-                
+
                 Ok(ClipboardItem {
                     id: row.get(0)?,
                     uuid,
@@ -856,7 +944,7 @@ pub fn limit_clipboard_history(max_count: u64) -> Result<(), String> {
     if max_count >= 999999 {
         return Ok(());
     }
-    
+
     let (images_to_delete, deleted_ids): (Vec<String>, Vec<i64>) = with_connection(|conn| {
         let sql_ids = "SELECT image_id FROM clipboard WHERE id NOT IN (SELECT id FROM clipboard ORDER BY is_pinned DESC, item_order DESC, updated_at DESC LIMIT ?1) AND image_id IS NOT NULL AND image_id <> ''";
         let mut stmt = conn.prepare(sql_ids)?;
@@ -911,14 +999,21 @@ pub fn delete_clipboard_item(id: i64) -> Result<(), String> {
             .query_row(
                 "SELECT image_id, uuid FROM clipboard WHERE id = ?",
                 params![id],
-                |row| Ok((row.get::<_, Option<String>>(0)?, row.get::<_, Option<String>>(1)?)),
+                |row| {
+                    Ok((
+                        row.get::<_, Option<String>>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                    ))
+                },
             )
             .optional()?;
         let Some((image_ids, uuid)) = item else {
             return Ok(Vec::new());
         };
         let deleted_at = chrono::Local::now().timestamp();
-        let tombstone_id = uuid.filter(|value| !value.trim().is_empty()).unwrap_or_else(|| id.to_string());
+        let tombstone_id = uuid
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| id.to_string());
         super::tombstones::record_sync_tombstone_in_conn(
             conn,
             super::tombstones::COLLECTION_HISTORY,
@@ -964,7 +1059,12 @@ pub fn delete_clipboard_items(ids: &[i64]) -> Result<(), String> {
                 .query_row(
                     "SELECT image_id, uuid FROM clipboard WHERE id = ?",
                     params![id],
-                    |row| Ok((row.get::<_, Option<String>>(0)?, row.get::<_, Option<String>>(1)?)),
+                    |row| {
+                        Ok((
+                            row.get::<_, Option<String>>(0)?,
+                            row.get::<_, Option<String>>(1)?,
+                        ))
+                    },
                 )
                 .optional()?;
 
@@ -974,7 +1074,10 @@ pub fn delete_clipboard_items(ids: &[i64]) -> Result<(), String> {
                         image_id_set.insert(image_id);
                     }
                 }
-                tombstone_ids.push(uuid.filter(|value| !value.trim().is_empty()).unwrap_or_else(|| id.to_string()));
+                tombstone_ids.push(
+                    uuid.filter(|value| !value.trim().is_empty())
+                        .unwrap_or_else(|| id.to_string()),
+                );
             }
         }
 
@@ -1014,9 +1117,7 @@ pub fn delete_clipboard_items(ids: &[i64]) -> Result<(), String> {
 // 清空所有剪贴板历史
 pub fn clear_clipboard_history() -> Result<(), String> {
     let images_to_delete: Vec<String> = with_connection(|conn| {
-        let mut stmt = conn.prepare(
-            "SELECT id, image_id, uuid FROM clipboard",
-        )?;
+        let mut stmt = conn.prepare("SELECT id, image_id, uuid FROM clipboard")?;
         let ids_iter = stmt.query_map([], |row| {
             Ok((
                 row.get::<_, i64>(0)?,
@@ -1033,7 +1134,10 @@ pub fn clear_clipboard_history() -> Result<(), String> {
                         set.insert(iid);
                     }
                 }
-                tombstone_ids.push(uuid.filter(|value| !value.trim().is_empty()).unwrap_or_else(|| id.to_string()));
+                tombstone_ids.push(
+                    uuid.filter(|value| !value.trim().is_empty())
+                        .unwrap_or_else(|| id.to_string()),
+                );
             }
         }
         drop(stmt);
@@ -1067,9 +1171,16 @@ pub fn clear_clipboard_history() -> Result<(), String> {
 }
 
 // 排序逻辑
-fn reorder_items(conn: &rusqlite::Connection, from_idx: usize, to_idx: usize, items: &[(i64, i64)]) -> Result<(), rusqlite::Error> {
-    if from_idx == to_idx { return Ok(()); }
-    
+fn reorder_items(
+    conn: &rusqlite::Connection,
+    from_idx: usize,
+    to_idx: usize,
+    items: &[(i64, i64)],
+) -> Result<(), rusqlite::Error> {
+    if from_idx == to_idx {
+        return Ok(());
+    }
+
     let tx = conn.unchecked_transaction()?;
     let now = chrono::Local::now().timestamp();
     let moved_id = items[from_idx].0;
@@ -1077,14 +1188,23 @@ fn reorder_items(conn: &rusqlite::Connection, from_idx: usize, to_idx: usize, it
 
     if from_idx < to_idx {
         for i in (from_idx + 1)..=to_idx {
-            tx.execute("UPDATE clipboard SET item_order = item_order + 1, updated_at = ?1 WHERE id = ?2", params![now, items[i].0])?;
+            tx.execute(
+                "UPDATE clipboard SET item_order = item_order + 1, updated_at = ?1 WHERE id = ?2",
+                params![now, items[i].0],
+            )?;
         }
     } else {
         for i in to_idx..from_idx {
-            tx.execute("UPDATE clipboard SET item_order = item_order - 1, updated_at = ?1 WHERE id = ?2", params![now, items[i].0])?;
+            tx.execute(
+                "UPDATE clipboard SET item_order = item_order - 1, updated_at = ?1 WHERE id = ?2",
+                params![now, items[i].0],
+            )?;
         }
     }
-    tx.execute("UPDATE clipboard SET item_order = ?1, updated_at = ?2 WHERE id = ?3", params![target_order, now, moved_id])?;
+    tx.execute(
+        "UPDATE clipboard SET item_order = ?1, updated_at = ?2 WHERE id = ?3",
+        params![target_order, now, moved_id],
+    )?;
     tx.commit()
 }
 
@@ -1092,12 +1212,14 @@ fn reorder_items(conn: &rusqlite::Connection, from_idx: usize, to_idx: usize, it
 pub fn move_clipboard_item_to_top(id: i64) -> Result<(), String> {
     with_connection(|conn| {
         let now = chrono::Local::now().timestamp();
-        let max_order: i64 = conn.query_row(
-            "SELECT COALESCE(MAX(item_order), 0) FROM clipboard WHERE is_pinned = 0",
-            [],
-            |row| row.get(0)
-        ).unwrap_or(0);
-        
+        let max_order: i64 = conn
+            .query_row(
+                "SELECT COALESCE(MAX(item_order), 0) FROM clipboard WHERE is_pinned = 0",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(0);
+
         conn.execute(
             "UPDATE clipboard SET item_order = ?1, updated_at = ?2 WHERE id = ?3 AND is_pinned = 0",
             params![max_order + 1, now, id],
@@ -1108,31 +1230,41 @@ pub fn move_clipboard_item_to_top(id: i64) -> Result<(), String> {
 
 // 移动剪贴板项
 pub fn move_clipboard_item_by_id(from_id: i64, to_id: i64) -> Result<(), String> {
-    if from_id == to_id { return Ok(()); }
+    if from_id == to_id {
+        return Ok(());
+    }
 
     with_connection(|conn| {
         let from_pinned: i64 = conn.query_row(
             "SELECT is_pinned FROM clipboard WHERE id = ?",
-            params![from_id], |row| row.get(0)
+            params![from_id],
+            |row| row.get(0),
         )?;
         let to_pinned: i64 = conn.query_row(
             "SELECT is_pinned FROM clipboard WHERE id = ?",
-            params![to_id], |row| row.get(0)
+            params![to_id],
+            |row| row.get(0),
         )?;
-        
+
         if from_pinned != to_pinned {
             return Ok(());
         }
-        
+
         let items: Vec<(i64, i64)> = conn.prepare("SELECT id, item_order FROM clipboard ORDER BY is_pinned DESC, item_order DESC, updated_at DESC")?
             .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
             .collect::<Result<Vec<_>, _>>()?;
 
-        let from_idx = items.iter().position(|(id, _)| *id == from_id)
-            .ok_or_else(|| rusqlite::Error::InvalidParameterName(format!("ID {} 不存在", from_id)))?;
-        let to_idx = items.iter().position(|(id, _)| *id == to_id)
+        let from_idx = items
+            .iter()
+            .position(|(id, _)| *id == from_id)
+            .ok_or_else(|| {
+                rusqlite::Error::InvalidParameterName(format!("ID {} 不存在", from_id))
+            })?;
+        let to_idx = items
+            .iter()
+            .position(|(id, _)| *id == to_id)
             .ok_or_else(|| rusqlite::Error::InvalidParameterName(format!("ID {} 不存在", to_id)))?;
-        
+
         reorder_items(conn, from_idx, to_idx, &items)
     })
 }
@@ -1188,23 +1320,156 @@ pub fn update_clipboard_item(
 pub fn toggle_pin_clipboard_item(id: i64) -> Result<bool, String> {
     with_connection(|conn| {
         let current_pinned: i64 = conn.query_row(
-            "SELECT is_pinned FROM clipboard WHERE id = ?", params![id], |row| row.get(0)
+            "SELECT is_pinned FROM clipboard WHERE id = ?",
+            params![id],
+            |row| row.get(0),
         )?;
-        
+
         let now = chrono::Local::now().timestamp();
         if current_pinned == 0 {
-            let max_pinned_order: i64 = conn.query_row(
-                "SELECT COALESCE(MAX(item_order), 0) FROM clipboard WHERE is_pinned = 1", [], |row| row.get(0)
-            ).unwrap_or(0);
+            let max_pinned_order: i64 = conn
+                .query_row(
+                    "SELECT COALESCE(MAX(item_order), 0) FROM clipboard WHERE is_pinned = 1",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap_or(0);
             conn.execute("UPDATE clipboard SET is_pinned = 1, item_order = ?1, updated_at = ?2 WHERE id = ?3", params![max_pinned_order + 1, now, id])?;
             Ok(true)
         } else {
-            let max_order: i64 = conn.query_row(
-                "SELECT COALESCE(MAX(item_order), 0) FROM clipboard WHERE is_pinned = 0", [], |row| row.get(0)
-            ).unwrap_or(0);
+            let max_order: i64 = conn
+                .query_row(
+                    "SELECT COALESCE(MAX(item_order), 0) FROM clipboard WHERE is_pinned = 0",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap_or(0);
             conn.execute("UPDATE clipboard SET is_pinned = 0, item_order = ?1, updated_at = ?2 WHERE id = ?3", params![max_order + 1, now, id])?;
             Ok(false)
         }
     })
 }
 
+#[cfg(test)]
+mod tests {
+    use super::super::connection::{close_database, init_database};
+    use super::*;
+    use std::sync::{Mutex, MutexGuard};
+
+    static TEST_DB_LOCK: Mutex<()> = Mutex::new(());
+
+    struct TestDatabase {
+        _guard: MutexGuard<'static, ()>,
+    }
+
+    impl Drop for TestDatabase {
+        fn drop(&mut self) {
+            close_database();
+        }
+    }
+
+    fn setup_test_database() -> TestDatabase {
+        let guard = TEST_DB_LOCK.lock().expect("test database lock poisoned");
+        close_database();
+        init_database(":memory:").expect("init test database");
+        TestDatabase { _guard: guard }
+    }
+
+    fn seed_text_items(contents: Vec<String>) {
+        with_connection(|conn| {
+            let tx = conn.unchecked_transaction()?;
+            for (index, content) in contents.iter().enumerate() {
+                let now = 1_700_000_000 + index as i64;
+                tx.execute(
+                    "INSERT INTO clipboard (
+                        content, content_type, item_order, is_pinned, paste_count,
+                        char_count, created_at, updated_at
+                     ) VALUES (?1, 'text', ?2, 0, 0, ?3, ?4, ?5)",
+                    rusqlite::params![
+                        content,
+                        index as i64,
+                        content.chars().count() as i64,
+                        now,
+                        now,
+                    ],
+                )?;
+            }
+            tx.commit()
+        })
+        .expect("seed clipboard items");
+    }
+
+    fn search_clipboard(search: &str, offset: i64, limit: i64) -> PaginatedResult<ClipboardItem> {
+        query_clipboard_items(QueryParams {
+            offset,
+            limit,
+            search: Some(search.to_string()),
+            content_type: None,
+        })
+        .expect("query clipboard items")
+    }
+
+    #[test]
+    fn search_large_history_returns_paginated_total() {
+        let _db = setup_test_database();
+        let long_tail = "x".repeat(SEARCH_CONTENT_PREFIX_LENGTH as usize + 512);
+        let contents = (0..3_000)
+            .map(|index| {
+                if index % 100 == 0 {
+                    format!("needle item {} {}", index, long_tail)
+                } else {
+                    format!("regular item {} {}", index, long_tail)
+                }
+            })
+            .collect();
+        seed_text_items(contents);
+
+        let result = search_clipboard("needle", 3, 7);
+
+        assert_eq!(result.total_count, 30);
+        assert_eq!(result.items.len(), 7);
+        assert!(result.has_more);
+        assert!(result
+            .items
+            .iter()
+            .all(|item| item.content.contains("needle")));
+    }
+
+    #[test]
+    fn search_like_metacharacters_match_literally() {
+        let _db = setup_test_database();
+        seed_text_items(vec![
+            "literal %_ marker".to_string(),
+            "literal ax marker".to_string(),
+            "literal percent underscore marker".to_string(),
+        ]);
+
+        let result = search_clipboard("%_", 0, 10);
+
+        assert_eq!(result.total_count, 1);
+        assert_eq!(result.items.len(), 1);
+        assert_eq!(result.items[0].content, "literal %_ marker");
+    }
+
+    #[test]
+    fn empty_result_then_broader_query_repopulates() {
+        let _db = setup_test_database();
+        seed_text_items(vec![
+            "alpha first".to_string(),
+            "beta second".to_string(),
+            "alpha third".to_string(),
+        ]);
+
+        let empty = search_clipboard("does-not-exist", 0, 10);
+        assert_eq!(empty.total_count, 0);
+        assert!(empty.items.is_empty());
+
+        let broader = search_clipboard("alpha", 0, 10);
+        assert_eq!(broader.total_count, 2);
+        assert_eq!(broader.items.len(), 2);
+        assert!(broader
+            .items
+            .iter()
+            .all(|item| item.content.contains("alpha")));
+    }
+}

--- a/src/shared/store/clipboardStore.js
+++ b/src/shared/store/clipboardStore.js
@@ -22,16 +22,25 @@ listen('paste-count-updated', (event) => {
 const CACHE_WINDOW_SIZE = 120
 const CACHE_BUFFER = 40
 let clipboardRequestVersion = 0
+let activeClipboardLoadVersion = null
 
 function nextClipboardRequestVersion() {
   clipboardRequestVersion += 1
   return clipboardRequestVersion
 }
 
-function isClipboardRequestCurrent(version, filter, contentType) {
-  return version === clipboardRequestVersion
-    && clipboardStore.filter === filter
-    && clipboardStore.contentType === contentType
+function createClipboardRequestContext(bumpVersion = false) {
+  return {
+    version: bumpVersion ? nextClipboardRequestVersion() : clipboardRequestVersion,
+    filter: clipboardStore.filter,
+    contentType: clipboardStore.contentType
+  }
+}
+
+function isClipboardRequestCurrent(context) {
+  return context?.version === clipboardRequestVersion
+    && clipboardStore.filter === context.filter
+    && clipboardStore.contentType === context.contentType
 }
 
 // 剪贴板 Store
@@ -429,11 +438,9 @@ export const clipboardStore = proxy({
 
 // 加载指定范围的数据
 export async function loadClipboardRange(startIndex, endIndex, requestContext = null) {
-  const requestVersion = requestContext?.version ?? clipboardRequestVersion
-  const requestFilter = requestContext?.filter ?? clipboardStore.filter
-  const requestContentType = requestContext?.contentType ?? clipboardStore.contentType
+  const context = requestContext ?? createClipboardRequestContext()
 
-  if (!isClipboardRequestCurrent(requestVersion, requestFilter, requestContentType)) {
+  if (!isClipboardRequestCurrent(context)) {
     return
   }
 
@@ -467,11 +474,11 @@ export async function loadClipboardRange(startIndex, endIndex, requestContext = 
     const result = await getClipboardHistory({
       offset: startIndex,
       limit,
-      contentType: requestContentType !== 'all' ? requestContentType : undefined,
-      search: requestFilter || undefined
+      contentType: context.contentType !== 'all' ? context.contentType : undefined,
+      search: context.filter || undefined
     })
 
-    if (!isClipboardRequestCurrent(requestVersion, requestFilter, requestContentType)) {
+    if (!isClipboardRequestCurrent(context)) {
       return
     }
     
@@ -483,12 +490,12 @@ export async function loadClipboardRange(startIndex, endIndex, requestContext = 
       clipboardStore.totalCount = result.total_count
     }
   } catch (err) {
-    if (isClipboardRequestCurrent(requestVersion, requestFilter, requestContentType)) {
+    if (isClipboardRequestCurrent(context)) {
       console.error(`加载范围 ${startIndex}-${endIndex} 失败:`, err)
       clipboardStore.error = err.message || '加载失败'
     }
   } finally {
-    if (isClipboardRequestCurrent(requestVersion, requestFilter, requestContentType)) {
+    if (isClipboardRequestCurrent(context)) {
       clipboardStore.removeLoadingRange(startIndex, endIndex)
     }
   }
@@ -500,10 +507,9 @@ export async function loadClipboardItems() {
 
 // 初始化加载
 export async function initClipboardItems() {
-  const requestVersion = nextClipboardRequestVersion()
-  const requestFilter = clipboardStore.filter
-  const requestContentType = clipboardStore.contentType
+  const context = createClipboardRequestContext(true)
 
+  activeClipboardLoadVersion = context.version
   clipboardStore.loading = true
   clipboardStore.error = null
   
@@ -511,15 +517,15 @@ export async function initClipboardItems() {
     clipboardStore.items = {}
     clipboardStore.loadingRanges = new Set()
     
-    if (requestContentType !== 'all' || requestFilter) {
+    if (context.contentType !== 'all' || context.filter) {
       const result = await getClipboardHistory({
         offset: 0,
         limit: 100,
-        contentType: requestContentType !== 'all' ? requestContentType : undefined,
-        search: requestFilter || undefined
+        contentType: context.contentType !== 'all' ? context.contentType : undefined,
+        search: context.filter || undefined
       })
 
-      if (!isClipboardRequestCurrent(requestVersion, requestFilter, requestContentType)) {
+      if (!isClipboardRequestCurrent(context)) {
         return
       }
       
@@ -528,7 +534,7 @@ export async function initClipboardItems() {
     } else {
       const totalCount = await getClipboardTotalCount()
 
-      if (!isClipboardRequestCurrent(requestVersion, requestFilter, requestContentType)) {
+      if (!isClipboardRequestCurrent(context)) {
         return
       }
 
@@ -536,20 +542,17 @@ export async function initClipboardItems() {
       
       if (totalCount > 0) {
         const endIndex = Math.min(99, totalCount - 1)
-        await loadClipboardRange(0, endIndex, {
-          version: requestVersion,
-          filter: requestFilter,
-          contentType: requestContentType,
-        })
+        await loadClipboardRange(0, endIndex, context)
       }
     }
   } catch (err) {
-    if (isClipboardRequestCurrent(requestVersion, requestFilter, requestContentType)) {
+    if (isClipboardRequestCurrent(context)) {
       console.error('初始化剪贴板失败:', err)
       clipboardStore.error = err.message || '加载失败'
     }
   } finally {
-    if (isClipboardRequestCurrent(requestVersion, requestFilter, requestContentType)) {
+    if (activeClipboardLoadVersion === context.version) {
+      activeClipboardLoadVersion = null
       clipboardStore.loading = false
     }
   }
@@ -594,4 +597,3 @@ export async function pasteClipboardItem(id) {
     throw err
   }
 }
-

--- a/src/windows/main/components/ClipboardTab.jsx
+++ b/src/windows/main/components/ClipboardTab.jsx
@@ -32,7 +32,7 @@ const ClipboardTab = forwardRef(({
       } else {
         navigationStore.resetNavigation();
       }
-    }, query ? SEARCH_DEBOUNCE_DELAY : 0);
+    }, SEARCH_DEBOUNCE_DELAY);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Typing or backspacing in the clipboard search box no longer freezes the app on large histories. Search is moved off the hot path into the SQLite layer with indexed, paginated queries instead of loading and filtering the full history in memory per keystroke, and the frontend store debounces input and cancels stale in-flight queries (the backspace-after-zero-results case from the issue). Matches are still found anywhere in an entry's content - long entries are matched in full, with only the preview text truncated around the keyword.

## Why this matters

#376 reproduces a 100%-of-the-time UI freeze when searching a large mixed history, and a remaining backspace freeze even after the maintainer's suggested 500-item cap. The maintainer confirmed on 2026-06-06 that search performance "can indeed be optimized". This moves the cost from O(full history per keystroke, on the UI thread) to indexed paginated lookups, which also removes the freeze without needing the history cap.

## Testing

Unit tests added in `src-tauri/src/services/database/clipboard.rs` for the paginated search (match anywhere in long content, zero-result then backspace sequence, mixed text/image/file types, pagination boundaries). Note for the maintainer: the `gpu-image-viewer` SSH git dependency blocks full local builds for external contributors; CI on this PR will compile-verify. The diff is scoped to the database search layer, the clipboard store, and the ClipboardTab keystroke handling.

Fixes #376
