### PR TITLE
fix(构建): 社区构建时修补 Cargo.toml 移除私有 SSL 依赖

### DIFF
--- a/scripts/community-build.js
+++ b/scripts/community-build.js
@@ -14,6 +14,10 @@ const command = isDev ? 'dev' : 'build';
 
 const screenshotCapabilityPath = path.join(rootDir, 'src-tauri', 'capabilities', 'screenshot.json');
 const defaultCapabilityPath = path.join(rootDir, 'src-tauri', 'capabilities', 'default.json');
+const cargoTomlPath = path.join(rootDir, 'src-tauri', 'Cargo.toml');
+
+const PRIVATE_DEPENDENCY_PREFIXES = ['screenshot-suite = {', 'gpu-image-viewer = {'];
+const PRIVATE_FEATURE_NAMES = ['gpu-image-viewer', 'screenshot-suite'];
 
 function patchCapabilityFile(filePath) {
     if (!fs.existsSync(filePath)) return () => {};
@@ -39,13 +43,46 @@ function patchCapabilityFile(filePath) {
     };
 }
 
-function patchCapabilitiesForCommunity() {
+function patchCargoToml() {
+    if (!fs.existsSync(cargoTomlPath)) return () => {};
+
+    const original = fs.readFileSync(cargoTomlPath, 'utf8');
+    const modified = original
+        .split(/\r?\n/)
+        .filter((line) => {
+            const trimmed = line.trim();
+            if (PRIVATE_DEPENDENCY_PREFIXES.some((prefix) => trimmed.startsWith(prefix))) {
+                return false;
+            }
+            if (PRIVATE_FEATURE_NAMES.some((name) => {
+                const pattern = new RegExp(`^${name}\\s*=\\s*\\[`);
+                return pattern.test(trimmed) && trimmed.includes('dep:');
+            })) {
+                return false;
+            }
+            return true;
+        })
+        .map((line) => (line.trim().startsWith('default') ? 'default = []' : line))
+        .join('\n');
+
+    if (modified === original) return () => {};
+
+    fs.writeFileSync(cargoTomlPath, modified, 'utf8');
+
+    return () => {
+        fs.writeFileSync(cargoTomlPath, original, 'utf8');
+    };
+}
+
+function patchForCommunity() {
     if (!isCommunity) return () => {};
 
+    const restoreCargoToml = patchCargoToml();
     const restoreScreenshot = patchCapabilityFile(screenshotCapabilityPath);
     const restoreDefault = patchCapabilityFile(defaultCapabilityPath);
 
     return () => {
+        restoreCargoToml();
         restoreScreenshot();
         restoreDefault();
     };
@@ -62,13 +99,14 @@ console.log(`[build] 模式: ${isDev ? '开发' : '生产'}`);
 console.log(`[build] 执行: npm ${args.join(' ')}`);
 
 let restored = false;
-const restoreCapabilities = patchCapabilitiesForCommunity();
+const restorePatches = patchForCommunity();
 const restoreOnce = () => {
     if (restored) return;
     restored = true;
     try {
-        restoreCapabilities();
-    } catch {
+        restorePatches();
+    } catch (err) {
+        console.error('[build] 还原失败:', err.message);
     }
 };
 


### PR DESCRIPTION
## 问题

执行社区版构建时 Cargo 在 feature 解析前预先 fetch 所有 git 依赖（包括 `optional = true` 的私有依赖），导致无 SSH 密钥环境下构建失败。

## 方案

在 `community-build.js` 中新增 `patchCargoToml()`，构建前移除私有依赖和 feature 行：

- `split → filter → map → join` 流水线处理
- 移除 `screenshot-suite = {`、`gpu-image-viewer = {` 依赖行
- 移除 `[features]` 中含 `dep:` 引用的私有 feature 行（保留虚拟 feature）
- 将 `default = [...]` 重置为 `default = []`
- 构建结束后自动恢复原始文件

## 变更

`scripts/community-build.js` — 对比 09b33ee 仅新增空操作检测 + 错误日志