### PR TITLE
feat(设置): 关于页面版本号支持一键复制

### DIFF
--- a/src/shared/locales/en-US.json
+++ b/src/shared/locales/en-US.json
@@ -1069,7 +1069,9 @@
       "star": "Give a Star",
       "feedback": "Report Issues",
       "share": "Share & Recommend",
-      "donate": "Support & Donate"
+      "donate": "Support & Donate",
+      "clickToCopyVersion": "Click to copy version",
+      "versionCopied": "Version copied to clipboard"
     }
   },
   "footer": {

--- a/src/shared/locales/zh-CN.json
+++ b/src/shared/locales/zh-CN.json
@@ -1070,7 +1070,9 @@
       "star": "给个Star",
       "feedback": "反馈问题",
       "share": "推荐分享",
-      "donate": "赞赏支持"
+      "donate": "赞赏支持",
+      "clickToCopyVersion": "点击复制版本号",
+      "versionCopied": "版本号已复制到剪贴板"
     }
   },
   "footer": {

--- a/src/windows/settings/sections/AboutSection.jsx
+++ b/src/windows/settings/sections/AboutSection.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useState, useEffect } from 'react';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { getAppVersion } from '@shared/services/settingsService';
+import { copyTextToClipboard } from '@shared/api';
 import { toast } from '@shared/store/toastStore';
 import SettingsSection from '../components/SettingsSection';
 import SettingItem from '../components/SettingItem';
@@ -74,6 +75,15 @@ function AboutSection({
       setCheckingUpdate(false);
     }
   };
+  const handleCopyVersion = async () => {
+    try {
+      await copyTextToClipboard(`${t('settings.about.appName')} v${version}`);
+      toast.success(t('settings.about.versionCopied'));
+    } catch (error) {
+      console.error('复制版本号失败:', error);
+      toast.error(t('common.operationFailed'));
+    }
+  };
   const handleOpenGitHub = async () => {
     try {
       await openUrl(appLinks.github);
@@ -107,9 +117,14 @@ function AboutSection({
           <h3 className="text-xl font-bold text-qc-fg mb-1">
             {t('settings.about.appName')}
           </h3>
-          <p className="text-sm text-qc-fg-muted mb-3">
-            {t('settings.about.version')} {version}
-          </p>
+          <div
+            className="inline-flex items-center gap-1 cursor-pointer text-sm text-qc-fg-muted mb-3 hover:text-qc-fg transition-colors"
+            onClick={handleCopyVersion}
+            title={t('settings.about.clickToCopyVersion')}
+          >
+            <span>{t('settings.about.version')} {version}</span>
+            <i className="ti ti-copy text-xs opacity-60"></i>
+          </div>
           <p className="text-sm text-qc-fg-muted max-w-md mx-auto">
             {t('settings.about.descriptionText')}
           </p>


### PR DESCRIPTION
## 概述

在关于页面的版本号区域添加一键复制功能，点击后复制「QuickClipboard v0.4.0」格式的完整版本信息到剪贴板，并弹出 toast 提示。

## 改动

- `AboutSection.jsx`: 新增 click-to-copy 交互、复制图标、hover 样式
- `zh-CN.json / en-US.json`: 新增 `clickToCopyVersion` 和 `versionCopied` 两个国际化 key

## 效果

关于页面版本号行旁显示复制图标，点击后复制完整版本字符串（如「QuickClipboard v0.4.0」）到系统剪贴板，同时弹出 toast 提示复制成功。

Closes #175

<img width="1350" height="946" alt="PixPin_2026-06-15_04-03-49" src="https://github.com/user-attachments/assets/096ee664-af81-42a9-a774-e0bf161eb4e1" />