### PR TITLE
fix: tolerate WebDAV MKCOL conflicts so directory creation succeeds on more servers

### DIFF
--- a/src-tauri/src/services/webdav_sync/webdav_client.rs
+++ b/src-tauri/src/services/webdav_sync/webdav_client.rs
@@ -118,9 +118,9 @@ impl WebdavClient {
     pub async fn test_connection(&self) -> Result<(), String> {
         self.mkcol("").await?;
         self.mkcol("history").await?;
-        self.mkcol("history/chunks").await?;
+        self.mkcol_with_parent_retry("history", "history/chunks").await?;
         self.mkcol("favorites").await?;
-        self.mkcol("favorites/chunks").await?;
+        self.mkcol_with_parent_retry("favorites", "favorites/chunks").await?;
         self.mkcol("groups").await?;
         self.mkcol("files").await?;
         self.mkcol("tombstones").await?;
@@ -355,14 +355,50 @@ impl WebdavClient {
     pub async fn mkcol(&self, path: &str) -> Result<(), String> {
         let method = Method::from_bytes(b"MKCOL").map_err(|e| e.to_string())?;
         let resp = self.request(method, path).send().await.map_err(map_reqwest_error)?;
-        if resp.status().is_success()
-            || resp.status() == StatusCode::METHOD_NOT_ALLOWED
-            || resp.status().as_u16() == 405
+        let status = resp.status();
+        if status.is_success()
+            || status == StatusCode::METHOD_NOT_ALLOWED
+            || status.as_u16() == 405
         {
             Ok(())
+        } else if status == StatusCode::CONFLICT && self.collection_exists(path).await? {
+            Ok(())
         } else {
-            Err(format_webdav_status_error("创建 WebDAV 目录失败", resp.status()))
+            Err(format_webdav_status_error("创建 WebDAV 目录失败", status))
         }
+    }
+
+    async fn collection_exists(&self, path: &str) -> Result<bool, String> {
+        let method = Method::from_bytes(b"PROPFIND").map_err(|e| e.to_string())?;
+        let resp = self
+            .request(method, path)
+            .header("Depth", "0")
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
+        let status = resp.status();
+        if status == StatusCode::NOT_FOUND || status == StatusCode::CONFLICT {
+            return Ok(false);
+        }
+        if status == StatusCode::UNAUTHORIZED
+            || status == StatusCode::FORBIDDEN
+            || status.as_u16() == 507
+            || status.is_server_error()
+        {
+            return Err(format_webdav_status_error("创建 WebDAV 目录失败", status));
+        }
+        Ok(true)
+    }
+
+    async fn mkcol_with_parent_retry(&self, parent: &str, path: &str) -> Result<(), String> {
+        if let Err(error) = self.mkcol(path).await {
+            if !is_webdav_conflict(&error) {
+                return Err(error);
+            }
+            self.mkcol(parent).await?;
+            self.mkcol(path).await?;
+        }
+        Ok(())
     }
 
     pub fn mark_dir_ensured(&self, path: &str) {

--- a/src-tauri/src/services/webdav_sync/webdav_client.rs
+++ b/src-tauri/src/services/webdav_sync/webdav_client.rs
@@ -377,17 +377,13 @@ impl WebdavClient {
             .await
             .map_err(map_reqwest_error)?;
         let status = resp.status();
+        if status.is_success() || status.as_u16() == 207 {
+            return Ok(true);
+        }
         if status == StatusCode::NOT_FOUND || status == StatusCode::CONFLICT {
             return Ok(false);
         }
-        if status == StatusCode::UNAUTHORIZED
-            || status == StatusCode::FORBIDDEN
-            || status.as_u16() == 507
-            || status.is_server_error()
-        {
-            return Err(format_webdav_status_error("创建 WebDAV 目录失败", status));
-        }
-        Ok(true)
+        Err(format_webdav_status_error("创建 WebDAV 目录失败", status))
     }
 
     async fn mkcol_with_parent_retry(&self, parent: &str, path: &str) -> Result<(), String> {


### PR DESCRIPTION
## Summary

WebDAV "Test connection" / "Push to WebDAV" now succeeds against servers that answer MKCOL with a 409 Conflict for collections that already exist, instead of aborting with "创建 WebDAV 目录失败，请检查根目录权限". Genuine auth, permission, and quota errors still surface as before.

## Why this matters

In #400 a user on a valid WebDAV server (the same server syncs fine with super-productivity) cannot sync because directory creation fails. The cause is in `mkcol()`: it only treated success and 405 Method Not Allowed as "already exists" and propagated everything else, including 409 Conflict, as a hard failure. Many WebDAV servers return 409 for a collection that already exists or when a trailing slash is normalized, and some require the parent collection to exist before a nested MKCOL. The codebase already accepts a 409-retry pattern in `ensure_cloud_files_dir`, so this extends the same tolerance to the connection-test path.

Changes:
- `mkcol()` treats a 409 as success only when a `PROPFIND Depth: 0` probe confirms the collection is actually present; a genuinely missing collection still returns the mapped error so callers can create the parent and retry.
- The existence probe only confirms presence on a positive (2xx / 207) response and surfaces unexpected statuses, so a rejected probe never masks a real failure.
- `test_connection()` creates the nested `history/chunks` and `favorites/chunks` collections with a parent-first retry on conflict, mirroring `ensure_cloud_files_dir`.
- 401 / 403 / 404 / 507 / 5xx responses still map to their existing error messages, so real permission and quota failures are not turned into false successes.

## Testing

`cargo` build/test could not run locally because the crate depends on the private `mosheng1/gpu-image-viewer` git source, which is not fetchable in this environment. The change is confined to MKCOL conflict handling in `webdav_client.rs` and reuses existing helpers (`format_webdav_status_error`, `is_webdav_conflict`) and the established 409-retry pattern.

Fixes #400
