### PR TITLE
fix(build): 修复 SIGINT 竞态，新增残留检测，完善中断处理

### DIFF
--- a/scripts/build-tauri.js
+++ b/scripts/build-tauri.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import fs from 'node:fs/promises'
 import { existsSync } from 'node:fs'
+import { ensureCleanWorkspace } from './ensure-clean-workspace.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -10,9 +11,17 @@ const rootDir = path.resolve(__dirname, '..')
 
 const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm'
 
+let child = null
+let interrupted = false
+
+// 启动 Vite 构建，返回 Promise。信号中断时 reject 触发 finally 清理
 function run(cwd, args) {
   return new Promise((resolve, reject) => {
-    const child = spawn(npmCmd, args, {
+    if (interrupted) {
+      reject(new Error('中断'))
+      return
+    }
+    child = spawn(npmCmd, args, {
       cwd,
       stdio: 'inherit',
       env: process.env,
@@ -20,6 +29,11 @@ function run(cwd, args) {
     })
 
     child.on('exit', (code) => {
+      child = null
+      if (interrupted) {
+        reject(new Error('中断'))
+        return
+      }
       if (code === 0) resolve()
       else reject(new Error(`${args.join(' ')} 失败，退出码 ${code}`))
     })
@@ -29,21 +43,21 @@ function run(cwd, args) {
 async function linkScreenshotSource() {
   const screenshotPluginSrc = path.join(rootDir, 'src-tauri', 'plugins', 'screenshot-suite', 'web', 'windows', 'screenshot')
   const mainProjectScreenshot = path.join(rootDir, 'src', 'windows', 'screenshot')
-  
+
   if (!existsSync(screenshotPluginSrc)) {
     throw new Error(`未找到截图插件源码: ${screenshotPluginSrc}`)
   }
-  
+
   if (existsSync(mainProjectScreenshot)) {
     await fs.rm(mainProjectScreenshot, { recursive: true, force: true })
   }
-  
+
   await fs.cp(screenshotPluginSrc, mainProjectScreenshot, { recursive: true })
 }
 
 async function unlinkScreenshotSource() {
   const mainProjectScreenshot = path.join(rootDir, 'src', 'windows', 'screenshot')
-  
+
   if (existsSync(mainProjectScreenshot)) {
     await fs.rm(mainProjectScreenshot, { recursive: true, force: true })
   }
@@ -51,9 +65,19 @@ async function unlinkScreenshotSource() {
 
 async function main() {
   const isCommunity = process.env.QC_COMMUNITY === '1'
+
+  // 完整版构建前检测并恢复社区构建遗留的补丁文件
+  if (!isCommunity) {
+    ensureCleanWorkspace()
+  }
+
   const hasScreenshotPlugin = !isCommunity && existsSync(
     path.join(rootDir, 'src-tauri', 'plugins', 'screenshot-suite', 'web', 'package.json')
   )
+
+  if (!isCommunity) {
+    ensureCleanWorkspace()
+  }
 
   try {
     if (hasScreenshotPlugin) {
@@ -61,7 +85,7 @@ async function main() {
     }
 
     await run(rootDir, ['run', 'build'])
-    
+
   } finally {
     if (hasScreenshotPlugin) {
       await unlinkScreenshotSource()
@@ -69,7 +93,23 @@ async function main() {
   }
 }
 
+process.on('SIGINT', () => {
+  if (interrupted) return
+  interrupted = true
+  try { child?.kill('SIGINT'); } catch {}
+})
+
+process.on('SIGTERM', () => {
+  if (interrupted) return
+  interrupted = true
+  try { child?.kill('SIGTERM'); } catch {}
+})
+
 main().catch((err) => {
-  console.error(err)
-  process.exit(1)
+  if (interrupted) {
+    console.error('[build] 编译中断，退出码: 130')
+  } else {
+    console.error(err)
+  }
+  process.exit(interrupted ? 130 : 1)
 })

--- a/scripts/community-build.js
+++ b/scripts/community-build.js
@@ -4,6 +4,7 @@ import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import fs from 'fs';
+import { ensureCleanWorkspace } from './ensure-clean-workspace.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.join(__dirname, '..');
@@ -15,6 +16,7 @@ const command = isDev ? 'dev' : 'build';
 const screenshotCapabilityPath = path.join(rootDir, 'src-tauri', 'capabilities', 'screenshot.json');
 const defaultCapabilityPath = path.join(rootDir, 'src-tauri', 'capabilities', 'default.json');
 const cargoTomlPath = path.join(rootDir, 'src-tauri', 'Cargo.toml');
+const cargoLockPath = path.join(rootDir, 'src-tauri', 'Cargo.lock');
 
 const PRIVATE_DEPENDENCY_PREFIXES = ['screenshot-suite = {', 'gpu-image-viewer = {'];
 const PRIVATE_FEATURE_NAMES = ['gpu-image-viewer', 'screenshot-suite'];
@@ -46,7 +48,11 @@ function patchCapabilityFile(filePath) {
 function patchCargoToml() {
     if (!fs.existsSync(cargoTomlPath)) return () => {};
 
+    ensureCleanWorkspace();
+
     const original = fs.readFileSync(cargoTomlPath, 'utf8');
+    // 保持原始换行符（CRLF/LF），避免 Windows 上格式变化
+    const eol = original.includes('\r\n') ? '\r\n' : '\n';
     const modified = original
         .split(/\r?\n/)
         .filter((line) => {
@@ -63,7 +69,7 @@ function patchCargoToml() {
             return true;
         })
         .map((line) => (line.trim().startsWith('default') ? 'default = []' : line))
-        .join('\n');
+        .join(eol);
 
     if (modified === original) return () => {};
 
@@ -74,17 +80,31 @@ function patchCargoToml() {
     };
 }
 
+// 备份 Cargo.lock，社区构建完成后恢复原状
+function backupCargoLock() {
+    if (!fs.existsSync(cargoLockPath)) return () => {};
+
+    const original = fs.readFileSync(cargoLockPath, 'utf8');
+
+    return () => {
+        fs.writeFileSync(cargoLockPath, original, 'utf8');
+    };
+}
+
+// 修补所有社区构建需要修改的文件，返回闭包用于恢复
 function patchForCommunity() {
     if (!isCommunity) return () => {};
 
     const restoreCargoToml = patchCargoToml();
     const restoreScreenshot = patchCapabilityFile(screenshotCapabilityPath);
     const restoreDefault = patchCapabilityFile(defaultCapabilityPath);
+    const restoreCargoLock = backupCargoLock();
 
     return () => {
         restoreCargoToml();
         restoreScreenshot();
         restoreDefault();
+        restoreCargoLock();
     };
 }
 
@@ -98,6 +118,9 @@ console.log(`[build] 版本: ${edition}`);
 console.log(`[build] 模式: ${isDev ? '开发' : '生产'}`);
 console.log(`[build] 执行: npm ${args.join(' ')}`);
 
+// 修补前先检测并恢复上次中断残留的补丁文件
+ensureCleanWorkspace();
+
 let restored = false;
 const restorePatches = patchForCommunity();
 const restoreOnce = () => {
@@ -110,15 +133,7 @@ const restoreOnce = () => {
     }
 };
 
-process.on('SIGINT', () => {
-    restoreOnce();
-    process.exit(130);
-});
-
-process.on('SIGTERM', () => {
-    restoreOnce();
-    process.exit(143);
-});
+let interrupted = false;
 
 const child = spawn('npm', args, { 
     stdio: 'inherit', 
@@ -130,6 +145,21 @@ const child = spawn('npm', args, {
     }
 });
 
+// 信号中断时 kill 子进程，等 close 事件后再 restore，
+// 避免 cargo 退出时覆盖已恢复的 Cargo.lock
+process.on('SIGINT', () => {
+    if (interrupted) return;
+    interrupted = true;
+    try { child.kill('SIGINT'); } catch {}
+    // 不在此恢复，等 child close 事件确保子进程已完全退出
+});
+
+process.on('SIGTERM', () => {
+    if (interrupted) return;
+    interrupted = true;
+    try { child.kill('SIGTERM'); } catch {}
+});
+
 child.on('error', (err) => {
     restoreOnce();
     console.error(`[build] 启动失败: ${err.message}`);
@@ -138,10 +168,11 @@ child.on('error', (err) => {
 
 child.on('close', (code) => {
     restoreOnce();
-    if (code !== 0) {
-        console.error(`[build] 编译失败，退出码: ${code}`);
+    const exitCode = interrupted ? 130 : (code ?? 1);
+    if (exitCode !== 0) {
+        console.error(`[build] 编译${interrupted ? '中断' : '失败'}，退出码: ${exitCode}`);
     } else {
         console.log(`[build] ${edition}编译完成`);
     }
-    process.exit(code);
+    process.exit(exitCode);
 });

--- a/scripts/dev-tauri.js
+++ b/scripts/dev-tauri.js
@@ -2,7 +2,8 @@ import { spawn } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import fs from 'node:fs/promises'
-import { existsSync } from 'node:fs'
+import { existsSync, rmSync } from 'node:fs'
+import { ensureCleanWorkspace } from './ensure-clean-workspace.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -11,6 +12,7 @@ const rootDir = path.resolve(__dirname, '..')
 const isWin = process.platform === 'win32'
 
 function run(cwd, commandLine) {
+  if (interrupted) throw new Error('中断')
   const child = isWin
     ? spawn('cmd.exe', ['/d', '/s', '/c', commandLine], {
         cwd,
@@ -28,27 +30,21 @@ function run(cwd, commandLine) {
     process.exit(1)
   })
 
-  child.on('exit', (code) => {
-    if (code && code !== 0) {
-      process.exit(code)
-    }
-  })
-
   return child
 }
 
 async function linkScreenshotSource() {
   const screenshotPluginSrc = path.join(rootDir, 'src-tauri', 'plugins', 'screenshot-suite', 'web', 'windows', 'screenshot')
   const mainProjectScreenshot = path.join(rootDir, 'src', 'windows', 'screenshot')
-  
+
   if (!existsSync(screenshotPluginSrc)) {
     return false
   }
-  
+
   if (existsSync(mainProjectScreenshot)) {
     await fs.rm(mainProjectScreenshot, { recursive: true, force: true })
   }
-  
+
   if (process.platform === 'win32') {
     await fs.symlink(screenshotPluginSrc, mainProjectScreenshot, 'junction')
   } else {
@@ -59,42 +55,67 @@ async function linkScreenshotSource() {
 
 async function unlinkScreenshotSource() {
   const mainProjectScreenshot = path.join(rootDir, 'src', 'windows', 'screenshot')
-  
+
   if (existsSync(mainProjectScreenshot)) {
     await fs.rm(mainProjectScreenshot, { recursive: true, force: true })
   }
 }
 
 let host = null
+let interrupted = false
+let hasScreenshot = false
+
+// 信号中断时 kill Vite 子进程，子进程 exit 后输出消息并退出
+process.on('SIGINT', () => {
+  if (interrupted) return
+  interrupted = true
+  try { host?.kill(); } catch {}
+})
+
+process.on('SIGTERM', () => {
+  if (interrupted) return
+  interrupted = true
+  try { host?.kill(); } catch {}
+})
+
+process.on('exit', () => {
+  if (hasScreenshot) {
+    try { rmSync(path.join(rootDir, 'src', 'windows', 'screenshot'), { recursive: true, force: true }) } catch {}
+  }
+})
 
 async function main() {
   const isCommunity = process.env.QC_COMMUNITY === '1'
-  const screenshotWebDir = path.join(rootDir, 'src-tauri', 'plugins', 'screenshot-suite', 'web')
-  const hasScreenshotPlugin = !isCommunity && existsSync(path.join(screenshotWebDir, 'package.json'))
 
-  if (hasScreenshotPlugin) {
+  // 完整版构建前检测并恢复社区构建遗留的补丁文件
+  if (!isCommunity) {
+    ensureCleanWorkspace()
+  }
+
+  const screenshotWebDir = path.join(rootDir, 'src-tauri', 'plugins', 'screenshot-suite', 'web')
+  hasScreenshot = !isCommunity && existsSync(path.join(screenshotWebDir, 'package.json'))
+
+  if (hasScreenshot) {
     await linkScreenshotSource()
   }
 
   host = run(rootDir, 'npm run dev')
-}
 
-function shutdown() {
-  host?.kill()
-  unlinkScreenshotSource().catch(console.error)
+  host.on('exit', (code) => {
+    if (interrupted) {
+      console.error('[dev] 开发服务中断，退出码: 130')
+      process.exit(130)
+    } else if (code && code !== 0) {
+      process.exit(code)
+    }
+  })
 }
-
-process.on('SIGINT', () => {
-  shutdown()
-  process.exit(0)
-})
-process.on('SIGTERM', () => {
-  shutdown()
-  process.exit(0)
-})
 
 main().catch((err) => {
-  console.error(err)
-  shutdown()
-  process.exit(1)
+  if (interrupted) {
+    console.error('[dev] 开发服务中断，退出码: 130')
+  } else {
+    console.error(err)
+  }
+  process.exit(interrupted ? 130 : 1)
 })

--- a/scripts/ensure-clean-workspace.js
+++ b/scripts/ensure-clean-workspace.js
@@ -1,0 +1,53 @@
+// 检测并恢复因 SIGKILL 等强制中断遗留的构建补丁。
+// 社区构建时会移除 Cargo.toml 中 gpu-image-viewer / screenshot-suite
+// 的依赖及 feature 声明。若进程被强制终止，补丁未还原则残留。
+// 通过检测 Cargo.toml 是否缺少私有依赖行来识别，仅在确认残留时才恢复。
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const TOML = path.join(ROOT, 'src-tauri', 'Cargo.toml');
+const SCREENSHOT_CAP = path.join(ROOT, 'src-tauri', 'capabilities', 'screenshot.json');
+const DEFAULT_CAP = path.join(ROOT, 'src-tauri', 'capabilities', 'default.json');
+const CARGO_LOCK = path.join(ROOT, 'src-tauri', 'Cargo.lock');
+
+export function ensureCleanWorkspace() {
+  if (!fs.existsSync(TOML)) return;
+
+  // 检测 Cargo.toml 是否包含未注释的私有插件依赖行。
+  // 若依赖行存在 → 正常状态；若不存在 → 已处于补丁，需恢复
+  const content = fs.readFileSync(TOML, 'utf8');
+  const hasPrivate = content
+    .split(/\r?\n/)
+    .some((line) => {
+      const t = line.trim();
+      if (t.startsWith('#')) return false;
+      return t.startsWith('screenshot-suite = {') || t.startsWith('gpu-image-viewer = {');
+    });
+
+  if (!hasPrivate) {
+    try {
+      // 记录补丁文件原始换行格式，git checkout 后原样恢复
+      const wasCRLF = content.includes('\r\n');
+      execSync(
+        `git checkout -- "${TOML}" "${SCREENSHOT_CAP}" "${DEFAULT_CAP}" "${CARGO_LOCK}"`,
+        { cwd: ROOT, stdio: 'pipe' }
+      );
+      if (wasCRLF) {
+        for (const f of [TOML, SCREENSHOT_CAP, DEFAULT_CAP, CARGO_LOCK]) {
+          if (fs.existsSync(f)) {
+            const c = fs.readFileSync(f, 'utf8');
+            if (!c.includes('\r\n')) {
+              fs.writeFileSync(f, c.replace(/\n/g, '\r\n'), 'utf8');
+            }
+          }
+        }
+      }
+      console.log('[build] 检测到上次构建中断残留，已自动恢复 Cargo.toml / capabilities / Cargo.lock');
+    } catch {
+      // 非 git 环境或无 checkout 权限，静默跳过
+    }
+  }
+}


### PR DESCRIPTION
## 变更

### 新增残留检测

**`scripts/ensure-clean-workspace.js`**（新增）

共享模块。检测 Cargo.toml 是否缺少 `gpu-image-viewer` / `screenshot-suite` 依赖行，若缺少则判定为社区构建 SIGKILL 残留，通过 `git checkout` 恢复 Cargo.toml、capabilities ×2、Cargo.lock 共 4 个文件。恢复时保持原始换行格式（`wasCRLF` 检测）。非 git 环境静默跳过。

### 修复中断处理

**`scripts/community-build.js`**

- 修复 SIGINT 竞态：kill 子进程后等 `close` 事件再 `restoreOnce`，避免 Cargo 退出时覆盖已恢复的 Cargo.lock
- 新增 `backupCargoLock`：构建前备份、构建后还原
- `patchCargoToml` 检测原始换行符（`\r\n` vs `\n`），修补时保持一致
- SIGTERM 同 SIGINT 处理
- 构建前调用 `ensureCleanWorkspace` 检测残留

**`scripts/build-tauri.js`**

- 新增 SIGINT/SIGTERM 处理：kill 子进程 → Promise reject → `finally` 清理截图 → 输出 `[build] 编译中断，退出码: 130`
- 完整版构建前调用 `ensureCleanWorkspace` 检测残留

**`scripts/dev-tauri.js`**

- 修复 SIGINT：kill Vite 子进程 → host exit 事件输出 `[dev] 开发服务中断，退出码: 130`
- `process.on('exit')` 同步清理截图
- 完整版构建前调用 `ensureCleanWorkspace` 检测残留

### 覆盖

| 入口 | 残留检测 |
|------|---------|
| `npm run tauri:build` | `build-tauri.js` |
| `npm run tauri:dev` | `dev-tauri.js` |
| `npm run tauri:build:community` | `community-build.js` |
| `npm run tauri:dev:community` | `community-build.js` |

## 已验证

基于最新提交在 Windows 上测试：

| 场景 | 结果 |
|------|------|
| 社区发行版构建 | 编译通过 |
| 完整发行版构建 | 预期报错（需 SSH key） |
| 社区开发版构建 | 编译通过 |
| 完整开发版构建 | 预期报错（需 SSH key） |
| 所有脚本 Ctrl+C 中断 | 有提示消息 + 自动清理临时文件 |
| 残留检测（编译前） | 完整版和社区版均正常检测并恢复 |
