### PR TITLE
feat: 修复托盘点击切换与动画闪跳问题

### DIFF
--- a/src-tauri/src/services/system/raw_input.rs
+++ b/src-tauri/src/services/system/raw_input.rs
@@ -19,10 +19,12 @@ mod windows_raw_input {
         GetRawInputData, RegisterRawInputDevices, HRAWINPUT, RAWINPUT, RAWINPUTDEVICE, RAWINPUTHEADER,
         RID_INPUT, RIDEV_INPUTSINK,
     };
+    use windows::Win32::Foundation::POINT;
     use windows::Win32::UI::WindowsAndMessaging::{
-        CreateWindowExW, DefWindowProcW, DispatchMessageW, GetMessageW, PeekMessageW, RegisterClassExW,
-        TranslateMessage, CS_HREDRAW, CS_VREDRAW, CW_USEDEFAULT, MSG, PM_NOREMOVE, WM_DESTROY, WM_INPUT,
-        WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN, WM_SYSKEYUP, WNDCLASSEXW, WS_OVERLAPPEDWINDOW,
+        CreateWindowExW, DefWindowProcW, DispatchMessageW, GetClassNameW, GetMessageW, GetParent,
+        PeekMessageW, RegisterClassExW, TranslateMessage, WindowFromPoint, CS_HREDRAW, CS_VREDRAW,
+        CW_USEDEFAULT, MSG, PM_NOREMOVE, WM_DESTROY, WM_INPUT, WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN,
+        WM_SYSKEYUP, WNDCLASSEXW, WS_OVERLAPPEDWINDOW,
     };
 
     use crate::services::sound::AppSounds;
@@ -730,6 +732,53 @@ mod windows_raw_input {
         });
     }
 
+    // 检测鼠标是否在系统托盘区域（含任务栏通知区域、溢出区域、本程序托盘图标），
+    // 用于避免把托盘点击误判为"窗口外点击"而错误隐藏主窗口。
+    //
+    // 从 WindowFromPoint 返回的窗口开始，向上遍历最多 10 层父窗口链，
+    // 若任一级别窗口类名命中预定义列表，则视为托盘区域点击。
+    //
+    // 需要遍历父窗口链的原因：通知区域图标嵌入在 ToolbarWindow32 → SysPager
+    // → TrayNotifyWnd → Shell_TrayWnd 层级中，WindowFromPoint 返回的是深层
+    // 子窗口（如 ToolbarWindow32），不直接返回 Shell_TrayWnd。
+    //
+    // 注意：tray_icon_app 依赖 Tauri tray-icon 组件内部窗口类名，若未来变更需同步更新。
+    fn is_cursor_on_system_tray_impl() -> bool {
+        const TRAY_CLASSES: &[&str] = &[
+            "Shell_TrayWnd",
+            "Shell_SecondaryTrayWnd",
+            "NotifyIconOverflowWindow",
+            "TopLevelWindowForOverflowXamlIsland",
+            "tray_icon_app",
+        ];
+
+        let (x, y) = crate::mouse::get_cursor_position();
+        let mut hwnd = unsafe { WindowFromPoint(POINT { x, y }) };
+        if hwnd.0.is_null() {
+            return false;
+        }
+
+        fn get_class(hwnd: HWND) -> Option<String> {
+            let mut buf = [0u16; 64];
+            let len = unsafe { GetClassNameW(hwnd, &mut buf) };
+            (len > 0).then(|| String::from_utf16_lossy(&buf[..len as usize]))
+        }
+
+        for _ in 0..10 {
+            if let Some(class) = get_class(hwnd) {
+                if TRAY_CLASSES.iter().any(|&c| c == class.as_str()) {
+                    return true;
+                }
+            }
+            hwnd = match unsafe { GetParent(hwnd) } {
+                Ok(h) if !h.0.is_null() => h,
+                _ => break,
+            };
+        }
+
+        false
+    }
+
     fn is_mouse_outside_window_impl(window: &WebviewWindow) -> bool {
         let (cursor_x, cursor_y) = crate::mouse::get_cursor_position();
 
@@ -802,6 +851,12 @@ mod windows_raw_input {
         }
 
         if !should_handle_click_outside_impl() {
+            return;
+        }
+
+        // 托盘区域点击（任务栏通知区域 / 溢出区域 / 托盘图标）不触发主窗口隐藏，
+        // 避免与托盘图标的 click 事件产生 show/hide 竞争导致动画闪跳。
+        if is_cursor_on_system_tray_impl() {
             return;
         }
 

--- a/src-tauri/src/windows/main_window/visibility.rs
+++ b/src-tauri/src/windows/main_window/visibility.rs
@@ -219,7 +219,10 @@ fn hide_normal_window(window: &WebviewWindow) {
 
     let settings = crate::get_settings();
     if settings.clipboard_animation_enabled {
-        std::thread::sleep(std::time::Duration::from_millis(200));
+        // 等待前端收起动画（animateCollapse, 200ms）完成。
+        // emit 是异步的，前端收到事件并开始动画有延迟，因此 sleep 略大于动画时长，
+        // 确保 window.hide() 时 opacity 已归零，避免下次 show 时出现全亮闪跳。
+        std::thread::sleep(std::time::Duration::from_millis(250));
     }
 
     let mut settings_to_save = None;
@@ -270,6 +273,7 @@ fn hide_normal_window(window: &WebviewWindow) {
     }
 
     let _ = window.hide();
+
     set_window_state(WindowState::Hidden);
     crate::services::memory::schedule_cleanup_after_main_window_hide();
 

--- a/src-tauri/src/windows/tray/events.rs
+++ b/src-tauri/src/windows/tray/events.rs
@@ -10,9 +10,9 @@ pub fn handle_tray_click(app: &AppHandle) {
         }
         return;
     }
-    if let Some(window) = app.get_webview_window("main") {
-        crate::show_main_window(&window);
-    }
+    // 使用 toggle 替代无条件的 show，使托盘点击能够正确切换显示/隐藏状态。
+    // 配合 raw_input 中的托盘区域检测，避免双击/快速点击时 show 与 hide 竞争导致动画闪跳。
+    crate::toggle_main_window_visibility(app);
 }
 
 pub fn create_click_handler(app_handle: AppHandle) -> impl Fn() + Send + 'static {

--- a/src/shared/hooks/useWindowAnimation.js
+++ b/src/shared/hooks/useWindowAnimation.js
@@ -2,82 +2,112 @@ import { useEffect } from 'react'
 import { listen } from '@tauri-apps/api/event'
 import { settingsStore } from '@shared/store/settingsStore'
 
-// 展开动画
-function animateExpand(container) {
-  const duration = 400
-  const startTime = performance.now()
-  const targetHeight = window.innerHeight - 10
-
-  container.style.height = '0'
-  container.style.opacity = '0'
-  container.style.overflow = 'hidden'
-
-  function easeWithSettleBounce(t) {
-    if (t < 0.7) {
-      const normalized = t / 0.7
-      return 1 - Math.pow(1 - normalized, 3)
-    }
-
-    const settlePhase = (t - 0.7) / 0.3
-    const overshoot = Math.cos(settlePhase * Math.PI) * 0.012
-    return 1 - overshoot * (1 - settlePhase)
-  }
-
-  function animate(currentTime) {
-    const progress = Math.min((currentTime - startTime) / duration, 1)
-    const eased = easeWithSettleBounce(progress)
-    
-    container.style.height = `${targetHeight * eased}px`
-    container.style.opacity = Math.min(progress * 2, 1)
-
-    if (progress < 1) {
-      requestAnimationFrame(animate)
-    } else {
-      container.style.height = 'calc(100vh - 10px)'
-      container.style.opacity = '1'
-    }
-  }
-
-  requestAnimationFrame(animate)
-}
-
-// 收起动画
-function animateCollapse(container) {
-  const duration = 200
-  const startTime = performance.now()
-  const startHeight = window.innerHeight
-
-  container.style.height = 'calc(100vh - 10px)'
-  container.style.opacity = '1'
-  container.style.overflow = 'hidden'
-
-  function animate(currentTime) {
-    const progress = Math.min((currentTime - startTime) / duration, 1)
-    const eased = Math.pow(progress, 2)
-    
-    container.style.height = `${startHeight * (1 - eased)}px`
-    container.style.opacity = 1 - eased
-
-    if (progress < 1) {
-      requestAnimationFrame(animate)
-    } else {
-      container.style.height = '0'
-      container.style.opacity = '0'
-    }
-  }
-
-  requestAnimationFrame(animate)
-}
-
 export function useWindowAnimation() {
   useEffect(() => {
     const container = document.querySelector('.main-container')
     if (!container) return
 
+    // 记录当前正在运行的动画 rAF id，启动新动画前取消旧动画，
+    // 避免快速 show/hide 时 expand 与 collapse 两个 rAF 循环互相覆盖导致闪跳。
+    // 作为 effect 局部变量，天然隔离不同组件实例，无需 useRef。
+    let expandRafId = null
+    let collapseRafId = null
+
+    function cancelAllRaf() {
+      if (expandRafId) {
+        cancelAnimationFrame(expandRafId)
+        expandRafId = null
+      }
+      if (collapseRafId) {
+        cancelAnimationFrame(collapseRafId)
+        collapseRafId = null
+      }
+    }
+
+    // 展开动画
+    function animateExpand(container) {
+      // 取消所有正在进行的动画（含未完成的 expand），避免 rAF 泄漏导致并行动画互相覆盖
+      cancelAllRaf()
+
+      const duration = 400
+      const startTime = performance.now()
+      const targetHeight = window.innerHeight - 10
+
+      container.style.height = '0'
+      container.style.opacity = '0'
+      container.style.overflow = 'hidden'
+
+      function easeWithSettleBounce(t) {
+        if (t < 0.7) {
+          const normalized = t / 0.7
+          return 1 - Math.pow(1 - normalized, 3)
+        }
+
+        const settlePhase = (t - 0.7) / 0.3
+        const overshoot = Math.cos(settlePhase * Math.PI) * 0.012
+        return 1 - overshoot * (1 - settlePhase)
+      }
+
+      function animate(currentTime) {
+        const progress = Math.min((currentTime - startTime) / duration, 1)
+        const eased = easeWithSettleBounce(progress)
+
+        container.style.height = `${targetHeight * eased}px`
+        container.style.opacity = Math.min(progress * 2, 1)
+
+        if (progress < 1) {
+          expandRafId = requestAnimationFrame(animate)
+        } else {
+          expandRafId = null
+          container.style.height = 'calc(100vh - 10px)'
+          container.style.opacity = '1'
+        }
+      }
+
+      expandRafId = requestAnimationFrame(animate)
+    }
+
+    // 收起动画
+    function animateCollapse(container) {
+      // 取消所有正在进行的动画（含未完成的 collapse），避免 rAF 泄漏导致并行动画互相覆盖
+      cancelAllRaf()
+
+      const duration = 200
+      const startTime = performance.now()
+      // 从当前实际高度开始收起，避免从全高跳变（快速 show/hide 时当前高度可能不是全高）
+      // 使用 getComputedStyle 获取计算后的像素高度，兼容 calc() 等非像素单位，
+      // 避免 parseFloat('calc(100vh - 10px)') 返回 NaN 而回退到 window.innerHeight 导致首帧 10px 跳变
+      const currentHeight = parseFloat(getComputedStyle(container).height)
+      const startHeight = Number.isFinite(currentHeight) && currentHeight > 0
+        ? currentHeight
+        : window.innerHeight
+
+      container.style.overflow = 'hidden'
+
+      function animate(currentTime) {
+        const progress = Math.min((currentTime - startTime) / duration, 1)
+        const eased = Math.pow(progress, 2)
+
+        container.style.height = `${startHeight * (1 - eased)}px`
+        container.style.opacity = 1 - eased
+
+        if (progress < 1) {
+          collapseRafId = requestAnimationFrame(animate)
+        } else {
+          collapseRafId = null
+          container.style.height = '0'
+          container.style.opacity = '0'
+        }
+      }
+
+      collapseRafId = requestAnimationFrame(animate)
+    }
+
     const unlistenShow = listen('window-show-animation', () => {
       if (settingsStore.clipboardAnimationEnabled) {
         animateExpand(container)
       } else {
+        cancelAllRaf()
         container.style.height = 'calc(100vh - 10px)'
         container.style.opacity = '1'
       }
@@ -87,6 +117,7 @@ export function useWindowAnimation() {
       if (settingsStore.clipboardAnimationEnabled) {
         animateCollapse(container)
       } else {
+        cancelAllRaf()
         container.style.height = '0'
         container.style.opacity = '0'
         container.style.overflow = 'hidden'
@@ -105,7 +136,7 @@ export function useWindowAnimation() {
       unlistenShow.then(fn => fn())
       unlistenHide.then(fn => fn())
       clearTimeout(fallbackTimer)
+      cancelAllRaf()
     }
   }, [])
 }
-


### PR DESCRIPTION
## 问题

双击托盘图标时主窗口出现动画闪跳，由两个独立的根因导致：

### 根因 1：show/hide 竞争
Raw Input 全局监听（RIDEV_INPUTSINK）将托盘点击误判为窗口外点击 → 触发 hide_main_window()。随后 Tauri 托盘事件触发 show_main_window()，两者竞争导致窗口隐藏后立即重新显示。

### 根因 2：CSS 动画状态冲突
快速 show/hide 时，nimateExpand（400ms）和 nimateCollapse（200ms）的 requestAnimationFrame 循环互相覆盖 container.style.height；且 hide_normal_window 的 sleep（200ms）不足以等待前端动画完成，window.hide() 时 opacity 未归零，下次 show 出现全亮闪跳。

## 修复

### 提交 1：托盘区域检测并切换为 toggle 显示隐藏
- **raw_input.rs**：新增 is_cursor_on_system_tray_impl()，通过 WindowFromPoint + GetClassNameW + GetParent 遍历父窗口链检测托盘区域（Shell_TrayWnd / Shell_SecondaryTrayWnd / NotifyIconOverflowWindow / TopLevelWindowForOverflowXamlIsland / 	ray_icon_app），在 handle_click_outside_impl 中跳过托盘点击
- **events.rs**：handle_tray_click 从 show_main_window 改为 	oggle_main_window_visibility

### 提交 2：修复托盘切换时的动画闪跳
- **useWindowAnimation.js**：新增 cancelAllRaf() 辅助函数，nimateExpand / nimateCollapse 开头取消所有正在进行的 rAF；nimateCollapse 从当前实际高度收起（getComputedStyle），避免从全高跳变
- **visibility.rs**：hide_normal_window 的 sleep 从 200ms 增加到 250ms，补偿 emit 异步延迟，确保前端动画完成后再 window.hide()

## 演示

修复后的演示视频见评论。

Closes #345

## 验证
- [x] cargo check --no-default-features 编译通过
- [x] 社区版开发构建测试通过
- [x] 双击托盘图标无动画闪跳
- [x] 溢出区域托盘点击正常切换
- [x] 通知区域托盘点击正常切换