### PR TITLE
feat(托盘): 添加可选隐藏托盘图标开关

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -100,6 +100,7 @@ pub fn save_settings(mut settings: AppSettings, app: tauri::AppHandle) -> Result
     let webdav_crypto_scope_changed = old_settings.webdav_url != settings.webdav_url
         || old_settings.webdav_username != settings.webdav_username
         || old_settings.webdav_root_path != settings.webdav_root_path;
+    let show_tray_icon_changed = old_settings.show_tray_icon != settings.show_tray_icon;
 
     if edge_hide_changed && !settings.edge_hide_enabled {
         settings.edge_snap_position = None;
@@ -151,6 +152,14 @@ pub fn save_settings(mut settings: AppSettings, app: tauri::AppHandle) -> Result
             });
         } else if let Some(window) = app.get_webview_window("quickpaste") {
             let _ = window.close();
+        }
+    }
+
+    if show_tray_icon_changed {
+        if let Some(tray) = app.tray_by_id("main-tray") {
+            if let Err(e) = tray.set_visible(settings.show_tray_icon) {
+                eprintln!("切换托盘图标可见性失败: {}", e);
+            }
         }
     }
 

--- a/src-tauri/src/services/settings/model.rs
+++ b/src-tauri/src/services/settings/model.rs
@@ -11,6 +11,7 @@ pub struct AppSettings {
     pub auto_start: bool,
     pub run_as_admin: bool,
     pub start_hidden: bool,
+    pub show_tray_icon: bool,
     pub show_startup_notification: bool,
     pub tooltips_enabled: bool,
     pub auto_low_memory_enabled: bool,
@@ -211,6 +212,7 @@ impl Default for AppSettings {
             auto_start: false,
             run_as_admin: false,
             start_hidden: true,
+            show_tray_icon: true,
             show_startup_notification: true,
             tooltips_enabled: true,
             auto_low_memory_enabled: false,
@@ -440,5 +442,4 @@ mod tests {
         assert!(settings.app_filter_list.is_empty());
         assert_eq!(settings.app_filter_mode, "blacklist");
     }
-
 }

--- a/src-tauri/src/windows/tray/setup.rs
+++ b/src-tauri/src/windows/tray/setup.rs
@@ -1,7 +1,7 @@
 use image::GenericImageView;
 use tauri::{
     tray::{TrayIconBuilder, TrayIconEvent, MouseButton, MouseButtonState},
-    AppHandle,
+    AppHandle, Manager,
 };
 
 use super::create_click_handler;
@@ -63,6 +63,15 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
             }
         })
         .build(app)?;
+
+    // 启动时按设置隐藏托盘图标
+    if !crate::services::get_settings().show_tray_icon {
+        if let Some(tray) = app.tray_by_id("main-tray") {
+            if let Err(e) = tray.set_visible(false) {
+                eprintln!("隐藏托盘图标失败: {}", e);
+            }
+        }
+    }
 
     Ok(())
 }

--- a/src/shared/locales/en-US.json
+++ b/src/shared/locales/en-US.json
@@ -478,6 +478,8 @@
       "autoLowMemoryIdleMinutesDesc": "Automatically enter low memory mode when no window interaction occurs for the selected duration",
       "autoExitLowMemoryMode": "Auto Exit Low Memory Mode",
       "autoExitLowMemoryModeDesc": "Automatically exit low memory mode when showing the clipboard or taking a screenshot in low memory mode",
+      "showTrayIcon": "Show Tray Icon",
+      "showTrayIconDesc": "Show QuickClipboard icon in the system tray. When hidden, use shortcut to open settings and re-enable",
       "tooltipsEnabled": "Show Tooltips",
       "tooltipsEnabledDesc": "Show hints when hovering or focusing on elements",
       "historyLimit": "History Limit",

--- a/src/shared/locales/zh-CN.json
+++ b/src/shared/locales/zh-CN.json
@@ -478,6 +478,8 @@
       "autoLowMemoryIdleMinutesDesc": "超过该时长仍未与任意窗口交互时，自动进入低占用模式",
       "autoExitLowMemoryMode": "自动退出低占用模式",
       "autoExitLowMemoryModeDesc": "低占用模式下触发剪贴板显示或截屏时自动退出低占用模式",
+      "showTrayIcon": "显示托盘图标",
+      "showTrayIconDesc": "在系统托盘区域显示 QuickClipboard 图标，隐藏后可通过快捷键打开设置界面重新显示",
       "tooltipsEnabled": "显示提示框",
       "tooltipsEnabledDesc": "鼠标悬停或聚焦元素时显示提示信息",
       "historyLimit": "剪贴板历史数量",

--- a/src/shared/services/settingsService.js
+++ b/src/shared/services/settingsService.js
@@ -16,6 +16,7 @@ export const defaultSettings = {
   autoStart: false,
   runAsAdmin: false,
   startHidden: false,
+  showTrayIcon: true,
   showStartupNotification: true,
   autoLowMemoryEnabled: false,
   autoLowMemoryIdleMinutes: 15,

--- a/src/windows/settings/sections/GeneralSection.jsx
+++ b/src/windows/settings/sections/GeneralSection.jsx
@@ -200,6 +200,10 @@ function GeneralSection({
         <Toggle checked={settings.autoExitLowMemoryMode} onChange={checked => onSettingChange('autoExitLowMemoryMode', checked)} />
       </SettingItem>
 
+      <SettingItem label={t('settings.general.showTrayIcon')} description={t('settings.general.showTrayIconDesc')}>
+        <Toggle checked={settings.showTrayIcon} onChange={checked => onSettingChange('showTrayIcon', checked)} />
+      </SettingItem>
+
       <SettingItem label={t('settings.general.historyLimit')} description={t('settings.general.historyLimitDesc')}>
         <PresetInput
           type="number"


### PR DESCRIPTION
## 摘要

在设置「常规」页签中新增「显示托盘图标」开关，允许用户隐藏系统托盘中的 QuickClipboard 图标。

Closes #358

## 变更清单

| 文件 | 说明 |
|------|------|
| `src-tauri/src/services/settings/model.rs` | 新增 `show_tray_icon: bool`，默认 `true` |
| `src-tauri/src/windows/tray/setup.rs` | 启动时按设置隐藏托盘图标 |
| `src-tauri/src/commands/settings.rs` | 保存设置时检测变更，调用 `TrayIcon::set_visible()` |
| `src/shared/services/settingsService.js` | `defaultSettings` 新增 `showTrayIcon: true` |
| `src/windows/settings/sections/GeneralSection.jsx` | 新增开关组件 |
| `src/shared/locales/zh-CN.json` | 中文文案 |
| `src/shared/locales/en-US.json` | 英文文案 |

**7 文件，+30 -2**

## 行为说明

- 默认开启，保持现有行为不变
- 切换后托盘图标立即出现/消失，无需重启
- 重启后按设置恢复
- 隐藏后全局快捷键继续正常工作
- 描述文案包含恢复路径提示

## 测试结果

| # | 测试场景 | 预期结果 | 实际结果 |
|---|---------|---------|---------|
| **核心功能验证** |
| 1 | 默认状态 | 托盘图标可见 | ✅ |
| 2 | 关闭开关 | 托盘图标立即消失 | ✅ |
| 3 | 开启开关 | 托盘图标立即出现 | ✅ |
| 4 | 持久化-隐藏 | 重启后保持隐藏 | ✅ |
| 5 | 持久化-显示 | 重启后保持显示 | ✅ |
| 6 | 设置保存提示 | 显示"设置已保存" | ✅ |
| **快捷键交互（托盘隐藏时）** |
| 7 | 主窗口快捷键 | 主窗口正常弹出 | ✅ |
| 8 | 设置快捷键 | 设置窗口正常打开 | ✅ |
| 9 | 截图快捷键 | 截图功能正常触发 | ⏭ 跳过（社区版） |
| 10 | 快速粘贴快捷键 | 快速粘贴面板正常显示 | ✅ |
| **低占用模式交互** |
| 11 | 隐藏托盘→进低占用 | 托盘保持隐藏 | ✅ |
| 12 | 隐藏托盘→低占用→退出 | 托盘保持隐藏 | ✅ |
| 13 | 显示托盘→进低占用 | 托盘保持显示 | ✅ |
| 14 | 显示托盘→低占用→退出 | 托盘保持显示 | ✅ |
| 15 | 低占用中切换托盘开关 | 托盘立即变化，低占用不受影响 | ✅ |
| **重置与边界情况** |
| 16 | 重置默认 | 托盘恢复显示 | ✅ |
| 17 | 快速切换 3 次以上 | 无崩溃 | ✅ |
| 18 | 不修改即保存 | 托盘状态不变 | ✅ |
| 19 | 启动闪现 | 人眼不可察觉 | ✅ |
| **回归测试** |
| 20-26 | 剪贴板监控/快速粘贴/边缘隐藏/右键菜单/左键点击/窗口记忆 | 各功能正常，托盘不受影响 | ✅ |
| **i18n 验证** |
| 27 | 中文文案 | 显示"显示托盘图标"及描述 | ✅ |
| 28 | 英文文案 | 显示"Show Tray Icon"及描述 | ✅ |