### PR TITLE
feat(GroupsPopup): 快捷键切换分组时自动滚动列表

### DIFF
--- a/src/windows/main/App.jsx
+++ b/src/windows/main/App.jsx
@@ -429,7 +429,7 @@ function App() {
     groupsStore.setCurrentGroup(prevGroup.name);
     handleGroupChange(prevGroup.name);
     if (groupsPopupRef.current?.showTemporarily) {
-      groupsPopupRef.current.showTemporarily();
+      groupsPopupRef.current.showTemporarily(prevGroup.name);
     }
   };
 
@@ -449,7 +449,7 @@ function App() {
     groupsStore.setCurrentGroup(nextGroup.name);
     handleGroupChange(nextGroup.name);
     if (groupsPopupRef.current?.showTemporarily) {
-      groupsPopupRef.current.showTemporarily();
+      groupsPopupRef.current.showTemporarily(nextGroup.name);
     }
   };
 

--- a/src/windows/main/components/GroupsPopup.jsx
+++ b/src/windows/main/components/GroupsPopup.jsx
@@ -40,6 +40,7 @@ const SortableGroupItem = ({ group, isActive, onSelect, onEdit, onDelete, t, com
     <div
       ref={setNodeRef}
       style={style}
+      data-group-name={group.name}
       onClick={() => onSelect(group.name)}
       className="group relative w-full"
     >
@@ -146,6 +147,9 @@ const GroupsPopup = forwardRef(({
   const closeTimerRef = useRef(null);
   const animationTimerRef = useRef(null);
   const sidebarCollapseTimerRef = useRef(null);
+  const previousSidebarCollapsedRef = useRef(false);
+  const listContainerRef = useRef(null);
+  const pendingCloseRef = useRef(false);
   const isSidebarMode = mode === 'sidebar' || mode === 'tab-sidebar';
   const isTabMode = mode === 'tab';
 
@@ -293,40 +297,132 @@ const GroupsPopup = forwardRef(({
     setIsPinned(!isPinned);
   };
 
+  // sidebar 模式下自动收起面板并恢复用户原始折叠状态
+  const scheduleSidebarAutoClose = () => {
+    if (sidebarCollapseTimerRef.current) {
+      clearTimeout(sidebarCollapseTimerRef.current);
+    }
+    sidebarCollapseTimerRef.current = setTimeout(() => {
+      setIsOpen(false);
+      setIsSidebarCollapsed(previousSidebarCollapsedRef.current);
+      sidebarCollapseTimerRef.current = null;
+    }, 1200);
+  };
+
   // 临时显示分组面板
-  const showTemporarily = () => {
+  const showTemporarily = (groupName) => {
+    const targetGroup = groupName || groups.currentGroup;
+    const doScroll = () => {
+      if (targetGroup) {
+        scrollToActiveGroup(targetGroup);
+      }
+    };
+
     if (isSidebarMode) {
       if (isOpen && !isSidebarCollapsed) {
+        // 已展开，立即滚动并重置关闭定时器
+        doScroll();
+        scheduleSidebarAutoClose();
         return;
       }
 
-      if (sidebarCollapseTimerRef.current) {
-        clearTimeout(sidebarCollapseTimerRef.current);
-        sidebarCollapseTimerRef.current = null;
-      }
-
-      const previousCollapsedState = isSidebarCollapsed;
+      previousSidebarCollapsedRef.current = isSidebarCollapsed;
       setIsOpen(true);
       setIsSidebarCollapsed(false);
-      sidebarCollapseTimerRef.current = setTimeout(() => {
-        setIsOpen(false);
-        setIsSidebarCollapsed(previousCollapsedState);
-        sidebarCollapseTimerRef.current = null;
-      }, 1200);
+      // 面板已打开但收起时，等展开过渡动画完成（对应 sidebar duration-200）；否则双重 RAF 确保挂载
+      if (isOpen && isSidebarCollapsed) {
+        setTimeout(doScroll, 200);
+      } else {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            doScroll();
+          });
+        });
+      }
+      scheduleSidebarAutoClose();
       return;
     }
 
-    if (closeTimerRef.current) {
-      clearTimeout(closeTimerRef.current);
-      closeTimerRef.current = null;
-    }
+    const scheduleCloseAfterScroll = () => {
+      if (!isPinned && pendingCloseRef.current) {
+        if (closeTimerRef.current) {
+          clearTimeout(closeTimerRef.current);
+        }
+        closeTimerRef.current = setTimeout(() => {
+          closeTimerRef.current = null;
+          handleClose();
+        }, 500);
+      }
+    };
+    const doScrollAndScheduleClose = () => {
+      if (targetGroup) {
+        scrollToActiveGroup(targetGroup, () => {
+          scheduleCloseAfterScroll();
+        });
+      } else {
+        scheduleCloseAfterScroll();
+      }
+    };
+    pendingCloseRef.current = true;
     if (!isOpen) {
       setIsOpen(true);
+      if (uiAnimationEnabled) {
+        setTimeout(doScrollAndScheduleClose, 250);
+      } else {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            doScrollAndScheduleClose();
+          });
+        });
+      }
+    } else {
+      doScrollAndScheduleClose();
     }
-    if (!isPinned) {
-      closeTimerRef.current = setTimeout(() => {
-        handleClose();
+  };
+
+  const scrollToActiveGroup = (groupName, onScrollEnd) => {
+    const container = listContainerRef.current;
+    if (!container || !groupName) {
+      onScrollEnd?.();
+      return;
+    }
+    const items = container.querySelectorAll('[data-group-name]');
+    let activeEl = null;
+    for (let i = 0; i < items.length; i++) {
+      if (items[i].dataset.groupName === groupName) {
+        activeEl = items[i];
+        break;
+      }
+    }
+    if (!activeEl) {
+      onScrollEnd?.();
+      return;
+    }
+    const containerRect = container.getBoundingClientRect();
+    const elementRect = activeEl.getBoundingClientRect();
+    let targetScrollTop = container.scrollTop;
+    if (elementRect.top < containerRect.top) {
+      targetScrollTop -= containerRect.top - elementRect.top;
+    } else if (elementRect.bottom > containerRect.bottom) {
+      targetScrollTop += elementRect.bottom - containerRect.bottom;
+    }
+    if (targetScrollTop !== container.scrollTop) {
+      let settled = false;
+      const onSettle = () => {
+        if (settled) return;
+        settled = true;
+        onScrollEnd?.();
+      };
+      container.addEventListener('scrollend', onSettle, { once: true });
+      container.scrollTo({ top: targetScrollTop, behavior: 'smooth' });
+      setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        container.removeEventListener('scrollend', onSettle);
+        onScrollEnd?.();
       }, 500);
+    } else {
+      onScrollEnd?.();
     }
   };
 
@@ -342,6 +438,7 @@ const GroupsPopup = forwardRef(({
     if (isClosing) {
       return;
     }
+    pendingCloseRef.current = false;
     if (closeTimerRef.current) {
       clearTimeout(closeTimerRef.current);
       closeTimerRef.current = null;
@@ -469,6 +566,7 @@ const GroupsPopup = forwardRef(({
     const row = (
       <div
         key={group.name}
+        data-group-name={group.name}
         onClick={() => handleSelectGroup(group.name)}
         className="group relative w-full"
       >
@@ -592,7 +690,7 @@ const GroupsPopup = forwardRef(({
               )}
             </div>
 
-          <div className={`flex-1 min-h-0 overflow-y-auto py-1 ${isSidebarCollapsed ? 'px-1' : 'px-2'}`}>
+          <div ref={listContainerRef} className={`flex-1 min-h-0 overflow-y-auto py-1 ${isSidebarCollapsed ? 'px-1' : 'px-2'}`}>
             <div className="flex flex-col gap-1 items-stretch w-full min-w-0">
               {renderAllGroupRows(isSidebarCollapsed)}
               {renderSortableGroupList(isSidebarCollapsed)}
@@ -691,10 +789,11 @@ const GroupsPopup = forwardRef(({
             </div>
 
             {/* 分组列表 */}
-            <div className="flex-1 overflow-y-auto py-1">
+            <div ref={listContainerRef} className="flex-1 overflow-y-auto py-1">
               {groups.groups.filter(g => g.name === '全部').map(group => (
                 <div
                   key={group.name}
+                  data-group-name={group.name}
                   onClick={() => handleSelectGroup(group.name)}
                   className="group relative"
                 >


### PR DESCRIPTION
## 问题描述

使用 `Ctrl+↓` / `Ctrl+↑` 快捷键切换分组时，分组弹出面板不会滚动到当前分组，导致分组数量超过面板可视区域时无法确认当前切到了哪个分组。

用户原始报告：
> 用键盘操作，ctrl+向下键，移动到指定位置后，如果下面还有分组，那么向下移动时看不见具体移动到哪个组了，并且组是固定的，不动态向上滚动，所以组太多无法确认下面的组名，只能用鼠标中键滚动后才能看到。

## 变更摘要

| 文件 | 变动 |
|------|------|
| `App.jsx` | `handlePreviousGroup` / `handleNextGroup` 传递目标分组名给 `showTemporarily` |
| `GroupsPopup.jsx` | 新增 `scrollToActiveGroup` 滚动逻辑，三类面板模式（sidebar / tab / footer）均适配 |

### 核心改动

1. **`showTemporarily(groupName)`** — 接收目标分组名，通知面板自动滚动到指定分组
2. **`scrollToActiveGroup(groupName, onScrollEnd)`** — 基于 `getBoundingClientRect` 手动计算目标滚动位置，通过 `scrollend` 事件 + 500ms fallback 保证滚动完成回调可靠。避开了 `scrollIntoView` 在 WebView2 中的行为差异
3. **`data-group-name`** 属性 — 用于通过 dataset 精准定位目标分组 DOM 元素，避免 CSS 选择器特殊字符问题
4. **关闭定时器时序** — footer/tab 模式下，面板自动关闭计时在滚动动画完成后才启动，防止大量分组时面板提前关闭

## 测试结果

### 核心功能：全部通过 ✅

| # | 场景 | 结果 |
|---|------|------|
| 1 | Ctrl+↓ 向下切组（底部弹出） | ✅ |
| 2 | Ctrl+↑ 向上切组（底部弹出） | ✅ |
| 3 | Ctrl+↓ 向下切组（tab 模式） | ✅ |
| 4 | Ctrl+↑ 向上切组（tab 模式） | ✅ |
| 5-6 | Sidebar 展开时快捷键切组 | ✅ |
| 7-8 | Sidebar 收起时快捷键切组（临时展开） | ✅ |

### 动画 / 面板状态 / 边界条件：全部通过 ✅

| # | 场景 | 结果 |
|---|------|------|
| 9-12 | 动画开关下快捷键切组 | ✅ |
| 13 | 面板固定后快捷键切组 | ✅ |
| 14-15 | 面板已打开/展开时切组 | ✅ |
| 17 | 面板弹出后滚动到目标分组 | ✅ |
| 18-19 | 只有「全部」一个分组 | ✅ |
| 21-25 | 搜索框聚焦、特殊字符分组名、快速连按 | ✅ |

### 回归测试：全部通过 ✅

| # | 场景 | 结果 |
|---|------|------|
| 26-30 | ↑↓ 导航 / Enter 执行 / Ctrl+←→ 切标签 / Esc 隐藏 / Ctrl+P 固定 | ✅ |
| 32-40 | 鼠标切组 / 自动关闭 / 固定 / 拖拽排序 / 新增/编辑/删除 / Sidebar 折叠/展开 | ✅ |
| 41-46 | 标签栏下拉 / 窗口宽度切换布局 / 收藏夹可见性 / 窗口显隐 / 主题切换 | ✅ |
| 47-48 | 50+ 分组滚动流畅度 + 关闭时序 | ✅ |

### 测试中发现的已有问题（非本 PR 引入）

- 某些特定条件下固定面板仍会随自动关闭定时器关闭（疑似已有问题）
- **Ctrl+F 搜索键**：焦点不在搜索框时无反应
当焦点在搜索框时，使用Ctrl+F  将会调用出：

<img width="690" height="769" alt="image" src="https://github.com/user-attachments/assets/53edbb14-c971-4241-9a13-41d1a2cd65df" />

