### PR TITLE
fix: 升级安装后开机自启动丢失

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -408,7 +408,23 @@ pub fn run() {
                 
                 startup_diagnostics::set_startup_stage("执行 setup：加载设置");
                 let mut settings = get_settings();
-                
+
+                startup_diagnostics::set_startup_stage("执行 setup：同步开机自启注册表");
+                #[cfg(desktop)]
+                {
+                    use tauri_plugin_autostart::ManagerExt;
+                    let autostart_manager = app.autolaunch();
+                    if let Ok(current) = autostart_manager.is_enabled() {
+                        if current != settings.auto_start {
+                            if settings.auto_start {
+                                let _ = autostart_manager.enable();
+                            } else {
+                                let _ = autostart_manager.disable();
+                            }
+                        }
+                    }
+                }
+
                 if let Some((w, h)) = settings.saved_window_size.filter(|_| settings.remember_window_size) {
                     windows::main_window::apply_saved_window_size(&window, w, h);
                 }

--- a/src/windows/settings/sections/GeneralSection.jsx
+++ b/src/windows/settings/sections/GeneralSection.jsx
@@ -21,7 +21,6 @@ function GeneralSection({
   } = useTranslation();
   const [autoStartLoading, setAutoStartLoading] = useState(false);
   const [autoStartSynced, setAutoStartSynced] = useState(false);
-  const [autoStartMismatch, setAutoStartMismatch] = useState(false);
   const [runAsAdminLoading, setRunAsAdminLoading] = useState(false);
   const [currentlyRunningAsAdmin, setCurrentlyRunningAsAdmin] = useState(false);
 
@@ -31,9 +30,12 @@ function GeneralSection({
       try {
         const systemStatus = await getAutoStartStatus();
         if (systemStatus !== settings.autoStart) {
-          setAutoStartMismatch(true);
           console.warn('开机自启动状态不一致 - 系统:', systemStatus, '配置:', settings.autoStart);
-          await onSettingChange('autoStart', systemStatus);
+          try {
+            await setAutoStart(settings.autoStart);
+          } catch (setError) {
+            toast.error(t('settings.general.autoStartFailed'));
+          }
         }
         setAutoStartSynced(true);
       } catch (error) {


### PR DESCRIPTION
## 问题

NSIS 安装包升级时使用默认「卸载后安装」选项，导致注册表自启动键被删除后未恢复，开机自启动失效。

详见 [#421](https://github.com/mosheng1/QuickClipboard/issues/421)

## 修改

- **lib.rs**: 启动加载设置后，将注册表状态与存储的 auto_start 值同步
- **GeneralSection.jsx**: 状态不一致时用存储设置修复注册表（而非反向覆盖）

## 验证

Windows 沙盒复现升级场景，注册表自启动项已恢复。