### PR TITLE
fix: start the auto low-memory idle manager on setup (#419)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -363,6 +363,7 @@ pub fn run() {
                 services::store::init(app.handle());
                 startup_diagnostics::set_startup_stage("执行 setup：初始化低占用状态");
                 services::low_memory::init_window_activity_timestamp();
+                services::low_memory::init_auto_low_memory_manager(app.handle().clone());
                 startup_diagnostics::set_startup_stage("执行 setup：初始化低占用面板");
                 services::low_memory::init_panel(app.handle().clone())?;
                 #[cfg(desktop)]

--- a/src-tauri/src/services/low_memory/manager.rs
+++ b/src-tauri/src/services/low_memory/manager.rs
@@ -7,6 +7,7 @@ use super::state::{
     mark_window_activity,
     set_low_memory_mode,
     set_user_requested_exit,
+    should_enter_low_memory,
     try_mark_auto_manager_started,
     try_start_exit_low_memory,
     finish_exit_low_memory,
@@ -170,7 +171,13 @@ pub fn init_auto_low_memory_manager(app: AppHandle) {
                 .map(|duration| duration.as_millis() as u64)
                 .unwrap_or(last_activity_at_ms);
 
-            if now_ms.saturating_sub(last_activity_at_ms) < idle_threshold_ms {
+            if !should_enter_low_memory(
+                settings.auto_low_memory_enabled,
+                false,
+                last_activity_at_ms,
+                now_ms,
+                idle_threshold_ms,
+            ) {
                 continue;
             }
 

--- a/src-tauri/src/services/low_memory/state.rs
+++ b/src-tauri/src/services/low_memory/state.rs
@@ -34,6 +34,24 @@ pub fn init_window_activity_timestamp() {
     mark_window_activity();
 }
 
+/// Pure decision for the auto low-memory idle watcher. Returns true only when
+/// the feature is enabled, no tracked window is currently visible, activity has
+/// been recorded at least once (`last_activity_ms != 0`), and the elapsed idle
+/// time has reached the threshold.
+pub fn should_enter_low_memory(
+    enabled: bool,
+    any_window_visible: bool,
+    last_activity_ms: u64,
+    now_ms: u64,
+    idle_threshold_ms: u64,
+) -> bool {
+    if !enabled || any_window_visible || last_activity_ms == 0 {
+        return false;
+    }
+
+    now_ms.saturating_sub(last_activity_ms) >= idle_threshold_ms
+}
+
 pub fn try_mark_auto_manager_started() -> bool {
     !AUTO_MANAGER_STARTED.swap(true, Ordering::SeqCst)
 }
@@ -56,4 +74,35 @@ pub fn try_start_exit_low_memory() -> bool {
 // 完成退出低占用模式
 pub fn finish_exit_low_memory() {
     EXITING_LOW_MEMORY.store(false, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_enter_when_hidden_and_idle_reaches_threshold() {
+        assert!(should_enter_low_memory(true, false, 1_000, 62_000, 60_000));
+    }
+
+    #[test]
+    fn should_not_enter_when_window_visible() {
+        assert!(!should_enter_low_memory(true, true, 1_000, 61_000, 60_000));
+    }
+
+    #[test]
+    fn should_not_enter_when_disabled() {
+        assert!(!should_enter_low_memory(false, false, 1_000, 61_000, 60_000));
+    }
+
+    #[test]
+    fn should_not_enter_without_recorded_activity() {
+        assert!(!should_enter_low_memory(true, false, 0, 30_000, 60_000));
+    }
+
+    #[test]
+    fn should_enter_at_threshold_boundary_only() {
+        assert!(should_enter_low_memory(true, false, 1_000, 61_000, 60_000));
+        assert!(!should_enter_low_memory(true, false, 1_000, 60_999, 60_000));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the auto-enter low-memory mode never triggering in 0.4.0 (#419). Even with every window hidden and the idle duration elapsed, the app never switched into low-memory mode.

## Why

The 15-second idle watcher, `init_auto_low_memory_manager` in `services/low_memory/manager.rs`, is defined and re-exported from the module but never called anywhere in the codebase. The loop that counts idle time and triggers the transition is therefore never spawned, so the feature can never fire. This matches the report that the mode simply never activates.

## Changes

- Start the watcher during `setup` in `lib.rs`, right after the window-activity timestamp is initialized. The loop already guards against double-start via `try_mark_auto_manager_started()`, so a single call is enough.
- Extract the idle decision out of the async loop into a pure function `should_enter_low_memory(enabled, any_window_visible, last_activity_ms, now_ms, idle_threshold_ms)` in `low_memory/state.rs`, and add inline unit tests (matching the repo's existing inline-test style) covering: all windows hidden and idle past the threshold, a window still visible, the feature disabled, no activity recorded yet, and the exact threshold boundary.
- The loop now calls that pure function for its final decision. Behavior is otherwise unchanged.

## Testing

The new pure-function unit tests pass.

Fixes #419
