### PR TITLE
fix: 修复 HTML 内容保存后再通过纯文本编辑器修改时，预览已更新但粘贴仍使用旧 HTML 的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "tauri:build:community": "node scripts/community-build.js",
     "check:community": "node scripts/community-check.js check",
     "clippy:community": "node scripts/community-check.js clippy",
-    "test:rust": "node scripts/community-check.js test"
+    "test:rust": "node scripts/community-check.js test",
+    "test:text-editor": "node --test src/windows/textEditor/savePayload.test.js"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.11.2",

--- a/src/windows/textEditor/App.jsx
+++ b/src/windows/textEditor/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSnapshot } from 'valtio';
 import { settingsStore, initSettings } from '@shared/store/settingsStore';
@@ -20,6 +20,7 @@ import TextEditor from './components/TextEditor';
 import HtmlEditor from './components/HtmlEditor';
 import StatusBar from './components/StatusBar';
 import ToastContainer from '@shared/components/common/ToastContainer';
+import { resolveEditorSavePayload } from './savePayload';
 
 function resolveEditableTypes(contentType, htmlContent) {
   const normalizedType = String(contentType || '');
@@ -55,6 +56,7 @@ function App() {
   const [originalTextContent, setOriginalTextContent] = useState('');
   const [originalHtmlContent, setOriginalHtmlContent] = useState('');
   const [originalTitle, setOriginalTitle] = useState('');
+  const lastEditedModeRef = useRef(null);
 
   const [hasChanges, setHasChanges] = useState(false);
   const [charCount, setCharCount] = useState(0);
@@ -199,12 +201,15 @@ function App() {
     if (!editorData) return;
 
     try {
-      const htmlPayload = editableTypes.includes('html') ? htmlContent : undefined;
-      const htmlChanged = htmlPayload !== undefined && htmlPayload !== originalHtmlContent;
-      const textUnchanged = textContent === originalTextContent;
-      const contentForSave = htmlChanged && textUnchanged
-        ? extractPlainTextFromHtml(htmlPayload)
-        : textContent;
+      const { contentForSave, htmlPayload } = resolveEditorSavePayload({
+        supportsHtml: editableTypes.includes('html'),
+        textContent,
+        htmlContent,
+        originalTextContent,
+        originalHtmlContent,
+        lastEditedMode: lastEditedModeRef.current,
+        extractPlainTextFromHtml,
+      });
 
       if (editorData.type === 'clipboard') {
         await updateClipboardItem(editorData.id, contentForSave, htmlPayload);
@@ -283,7 +288,10 @@ function App() {
         {editMode === 'html' && editableTypes.includes('html') ? (
           <HtmlEditor
             content={htmlContent}
-            onContentChange={setHtmlContent}
+            onContentChange={(content) => {
+              lastEditedModeRef.current = 'html';
+              setHtmlContent(content);
+            }}
             onStatsChange={({ chars, lines }) => {
               setCharCount(chars);
               setLineCount(lines);
@@ -293,7 +301,10 @@ function App() {
         ) : (
           <TextEditor
             content={textContent}
-            onContentChange={setTextContent}
+            onContentChange={(content) => {
+              lastEditedModeRef.current = 'text';
+              setTextContent(content);
+            }}
             onStatsChange={({ chars, lines }) => {
               setCharCount(chars);
               setLineCount(lines);

--- a/src/windows/textEditor/savePayload.js
+++ b/src/windows/textEditor/savePayload.js
@@ -1,0 +1,40 @@
+export function resolveEditorSavePayload({
+  supportsHtml,
+  textContent,
+  htmlContent,
+  originalTextContent,
+  originalHtmlContent,
+  lastEditedMode,
+  extractPlainTextFromHtml,
+}) {
+  if (!supportsHtml) {
+    return {
+      contentForSave: textContent,
+      htmlPayload: undefined,
+    };
+  }
+
+  const textChanged = textContent !== originalTextContent;
+  const htmlChanged = htmlContent !== originalHtmlContent;
+
+  // Plain-text edits cannot be safely merged back into the previous HTML.
+  // Clear the stale HTML so formatted paste uses the newly edited text.
+  if (lastEditedMode === 'text' && textChanged) {
+    return {
+      contentForSave: textContent,
+      htmlPayload: '',
+    };
+  }
+
+  if (htmlChanged) {
+    return {
+      contentForSave: extractPlainTextFromHtml(htmlContent),
+      htmlPayload: htmlContent,
+    };
+  }
+
+  return {
+    contentForSave: textContent,
+    htmlPayload: htmlContent,
+  };
+}

--- a/src/windows/textEditor/savePayload.test.js
+++ b/src/windows/textEditor/savePayload.test.js
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveEditorSavePayload } from './savePayload.js';
+
+const extractPlainTextFromHtml = (html) => `plain:${html}`;
+
+test('clears stale HTML when plain text is the last edited representation', () => {
+  const result = resolveEditorSavePayload({
+    supportsHtml: true,
+    textContent: 'new text',
+    htmlContent: '<b>old HTML</b>',
+    originalTextContent: 'old HTML',
+    originalHtmlContent: '<b>old HTML</b>',
+    lastEditedMode: 'text',
+    extractPlainTextFromHtml,
+  });
+
+  assert.deepEqual(result, {
+    contentForSave: 'new text',
+    htmlPayload: '',
+  });
+});
+
+test('derives plain text when HTML is edited', () => {
+  const result = resolveEditorSavePayload({
+    supportsHtml: true,
+    textContent: 'old text',
+    htmlContent: '<b>new HTML</b>',
+    originalTextContent: 'old text',
+    originalHtmlContent: '<b>old HTML</b>',
+    lastEditedMode: 'html',
+    extractPlainTextFromHtml,
+  });
+
+  assert.deepEqual(result, {
+    contentForSave: 'plain:<b>new HTML</b>',
+    htmlPayload: '<b>new HTML</b>',
+  });
+});
+
+test('preserves unchanged HTML for non-content edits', () => {
+  const result = resolveEditorSavePayload({
+    supportsHtml: true,
+    textContent: 'text',
+    htmlContent: '<b>text</b>',
+    originalTextContent: 'text',
+    originalHtmlContent: '<b>text</b>',
+    lastEditedMode: null,
+    extractPlainTextFromHtml,
+  });
+
+  assert.deepEqual(result, {
+    contentForSave: 'text',
+    htmlPayload: '<b>text</b>',
+  });
+});


### PR DESCRIPTION
## 问题

HTML 内容保存后，再通过纯文本编辑器修改同一条目时，预览会显示最新纯文本，但格式粘贴仍优先使用旧的 HTML 内容。

## 原因

文本编辑器会分别保存纯文本和 HTML 两种表示。纯文本被修改后，原有 `html_content` 仍被保留，导致格式粘贴读取了已经过期的 HTML。

## 修复

- 记录最后实际修改的编辑模式
- 纯文本最后修改时移除过期的 HTML 保存表示，使粘贴使用最新纯文本
- HTML 最后修改时继续从 HTML 同步纯文本内容
- 增加保存载荷的回归测试

## 验证

- `npm run test:text-editor`：3 项测试通过
- `npm run build`：构建通过