### PR TITLE
fix(贴边隐藏): 透明残留框拦截点击并支持关闭悬浮弹出

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,68 @@
-logs
+# ============================================================
+# QuickClipboard 项目 .gitignore
+# 按类别组织,每节用 # === 标题 === 标头
+# ============================================================
+
+# === 操作系统文件 ===
+.DS_Store
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+
+# === 编辑器 / IDE 临时文件 ===
+# VSCode(允许提交 extensions.json 共享推荐扩展)
+.vscode/*
+!.vscode/extensions.json
+
+# JetBrains IDE
+.idea/
+*.iml
+*.iws
+*.ipr
+
+# Visual Studio
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.slnx
+
+# Emacs / Vim / 其他
+*~
+*.bak
+*.swp
+*.swo
+.vs/
+
+# === Node / 前端构建产物 ===
+node_modules/
+dist/
+dist-ssr/
+*.local
+.eslintcache
+.stylelintcache
+.parcel-cache
+.vite/
+
+# TypeScript 增量构建
+*.tsbuildinfo
+
+# === Rust / Tauri 构建产物 ===
+# Cargo target(覆盖任何深度的 target/)
+target/
+
+# tauri-build 生成的 capability schemas 与命令绑定
+src-tauri/gen/
+src-tauri/target/
+src-tauri/WixTools/
+src-tauri/bundle/
+
+# Rust 备份
+*.rs.bk
+
+# === 包管理器日志 ===
+logs/
 *.log
 npm-debug.log*
 yarn-debug.log*
@@ -6,38 +70,74 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
-node_modules
-dist
-dist-ssr
-*.local
+# === 本地环境与密钥 ===
+# 真实部署密钥、API token、用户特定路径配置
+.env
+.env.local
+.env.*.local
+!.env.example
+*.pem
+*.key
+secrets.*
+secrets/
 
-target
+# === 测试产物 / 覆盖率 ===
+coverage/
+*.lcov
+*.lcov.info
+junit.xml
+tarpaulin-report.html
+coverage.json
+.nyc_output/
 
-.vscode/*
-!.vscode/extensions.json
-.idea
-.DS_Store
-*.suo
-*.ntvs*
-*.njsproj
-*.sln
-*.sw?
+# === OMC 多智能体编排工具运行时状态 ===
+# 详见 CLAUDE.md §2(故意不入库)
+.omc/
+.omc/build.log
+.omc/*.log
+.omc/artifacts/
+
+# === AI 辅助开发本地规范文件,不入库 ===
+# 详见 CLAUDE.md §2(主人个人本地工作记忆,撤销忽略会让 git add . 误纳)
+CLAUDE.md
+
+# Claude Code 本地配置(只忽略本机覆盖,共享配置正常入仓)
+.claude/settings.local.json
+.claude/commands/local/
+.claude/agents/local/
+
+# === Tauri 私有依赖克隆(SSH git 仓库) ===
+# 详见 CLAUDE.md §15(本机 cargo check/test 需注释掉这两个 dep)
+src-tauri/plugins/gpu-image-viewer/
+src-tauri/plugins/screenshot-suite/
+
+# === 项目本地临时目录(不参与版本控制) ===
+# 截图模块原型的本地副本
+/src/windows/screenshot
+# Konva 截图实验目录
+screenshot_Konva
+# 前端独立子项目(若有)
+QuickClipboardWeb
+# 临时主项目工作区
+scap-main
+# 根级 OMC 协作产物(若直接放根,不入仓)
+/artifacts
+
+# === 历史规则(目录/文件已不存在,保留兼容旧 clone) ===
 **/mosqcg*
 .cu*
 /*ents*
 
-docs
-scap-main
-/plugins
-QuickClipboardWeb
-screenshot_Konva
-/src/windows/screenshot
-/src-tauri/plugins/gpu-image-viewer
+# === Bash 反斜杠误吃导致的泄露日志(本会话发现) ===
+# 见 CLAUDE.md §18 — git checkout 恢复 Cargo.toml 后,bash 把
+# `D:\newC\...cargo-test.log` 当字面路径创建了 21KB 残骸
+D:*.log
+D:newC*
+# === 防止类似泄露:屏蔽任何 Windows 盘符开头的根级文件 ===
+/[A-Z]:*
 
-# AI 辅助开发本地规范文件,不入库
-CLAUDE.md
-
-# OMC 多智能体编排工具运行时状态
-.omc/
-
-# TDD 回归测试已拆分到各源文件的 #[cfg(test)] 模块,不再需要独立 ignore 文件
+# === Cargo / Tauri 测试 workaround 残留文件 ===
+# 跑完 cargo test --lib --no-default-features 后必须 git checkout 恢复;
+# 万一漏恢复,以下规则会兜底,不把工作树改动误纳入 PR
+/src-tauri/Cargo.lock.local
+/src-tauri/Cargo.toml.local

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ QuickClipboardWeb
 screenshot_Konva
 /src/windows/screenshot
 /src-tauri/plugins/gpu-image-viewer
+
+# AI 辅助开发本地规范文件,不入库
+CLAUDE.md
+
+# OMC 多智能体编排工具运行时状态
+.omc/

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ screenshot_Konva
 /src/windows/screenshot
 /src-tauri/plugins/gpu-image-viewer
 
+# AI 辅助开发本地规范文件,不入库
+CLAUDE.md
+
 # OMC 多智能体编排工具运行时状态
 .omc/
 

--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,4 @@ CLAUDE.md
 # OMC 多智能体编排工具运行时状态
 .omc/
 
-# TDD 回归测试文件(不入库)
-src-tauri/src/tdd_tests.rs
+# TDD 回归测试已拆分到各源文件的 #[cfg(test)] 模块,不再需要独立 ignore 文件

--- a/.gitignore
+++ b/.gitignore
@@ -34,9 +34,6 @@ screenshot_Konva
 /src/windows/screenshot
 /src-tauri/plugins/gpu-image-viewer
 
-# AI 辅助开发本地规范文件,不入库
-CLAUDE.md
-
 # OMC 多智能体编排工具运行时状态
 .omc/
 

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ CLAUDE.md
 
 # OMC 多智能体编排工具运行时状态
 .omc/
+
+# TDD 回归测试文件(不入库)
+src-tauri/src/tdd_tests.rs

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -27,11 +27,7 @@ fn refresh_edge_hover_mode(app: &tauri::AppHandle) {
     if let Some(window) = app.get_webview_window("main") {
         let state = crate::windows::main_window::get_window_state();
         if state.is_snapped && state.is_hidden {
-            // 穿透/置顶/显隐的完整形态由 refresh_hidden_snapped_window 统一决策,
-            // 这里只需在开启分支先恢复可见,否则透明窗口 show 后触发条位置未刷新
-            if crate::get_settings().edge_hover_popup_enabled {
-                let _ = window.show();
-            }
+            // 穿透/置顶/显隐(含 show)由 refresh_hidden_snapped_window 统一决策
             let _ = crate::windows::main_window::refresh_hidden_snapped_window(&window);
         }
     }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -87,6 +87,12 @@ pub fn reload_settings() -> Result<AppSettings, String> {
 
 #[tauri::command]
 pub fn save_settings(mut settings: AppSettings, app: tauri::AppHandle) -> Result<(), String> {
+    // 守不变量:贴边悬浮弹出蕴含贴边隐藏,JSON 导入或非 UI 流程若留下 hover=true/hide=false
+    // 会在下次开启 hide 时意外弹出触发条 —— 此处一次性规范化
+    if !settings.edge_hide_enabled {
+        settings.edge_hover_popup_enabled = false;
+    }
+
     let old_settings = get_settings();
     let webdav_password = std::mem::take(&mut settings.webdav_password);
     if !webdav_password.is_empty() {

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -28,7 +28,8 @@ fn refresh_edge_hover_mode(app: &tauri::AppHandle) {
         let state = crate::windows::main_window::get_window_state();
         if state.is_snapped && state.is_hidden {
             let settings = crate::get_settings();
-            let _ = window.set_ignore_cursor_events(!settings.edge_hover_popup_enabled);
+            // 悬浮开启时触发条需点击穿透(避免拦截边缘点击),关闭时窗口真隐藏无需穿透
+            let _ = window.set_ignore_cursor_events(settings.edge_hover_popup_enabled);
             if settings.edge_hover_popup_enabled {
                 let _ = window.show();
                 let _ = window.set_always_on_top(true);
@@ -131,10 +132,6 @@ pub fn save_settings(mut settings: AppSettings, app: tauri::AppHandle) -> Result
         handle_disable_edge_hide(&app);
     }
 
-    if edge_hover_changed {
-        refresh_edge_hover_mode(&app);
-    }
-
     settings.update_check_interval = normalize_update_check_interval(&settings.update_check_interval);
     if remember_window_size_enabled {
         settings.saved_window_size = capture_main_window_logical_size(&app);
@@ -144,8 +141,13 @@ pub fn save_settings(mut settings: AppSettings, app: tauri::AppHandle) -> Result
     if webdav_crypto_scope_changed {
         crate::services::webdav_sync::crypto::clear_cached_keys();
     }
-    
+
     update_settings(settings.clone())?;
+
+    if edge_hover_changed {
+        // 新值已落地,再按新开关刷新贴边隐藏形态
+        refresh_edge_hover_mode(&app);
+    }
 
     if remember_window_size_disabled {
         restore_main_window_default_size(&app);

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -21,18 +21,6 @@ fn handle_disable_edge_hide(app: &tauri::AppHandle) {
     }
 }
 
-// 切换"鼠标移到边缘弹出"开关后,若主窗口正处于贴边隐藏状态,立即刷新其形态:
-// 开启 -> 露出透明触发条(保持置顶);关闭 -> 真正隐藏,不留透明条
-fn refresh_edge_hover_mode(app: &tauri::AppHandle) {
-    if let Some(window) = app.get_webview_window("main") {
-        let state = crate::windows::main_window::get_window_state();
-        if state.is_snapped && state.is_hidden {
-            // 穿透/置顶/显隐(含 show)由 refresh_hidden_snapped_window 统一决策
-            let _ = crate::windows::main_window::refresh_hidden_snapped_window(&window);
-        }
-    }
-}
-
 fn normalize_update_check_interval(value: &str) -> String {
     match value {
         "every3days" => "every3days".to_string(),
@@ -146,7 +134,13 @@ pub fn save_settings(mut settings: AppSettings, app: tauri::AppHandle) -> Result
 
     if edge_hover_changed {
         // 新值已落地,再按新开关刷新贴边隐藏形态
-        refresh_edge_hover_mode(&app);
+        if let Some(window) = app.get_webview_window("main") {
+            let state = crate::windows::main_window::get_window_state();
+            if state.is_snapped && state.is_hidden {
+                // 穿透/置顶/显隐(含 show)由 refresh_hidden_snapped_window 统一决策
+                let _ = crate::windows::main_window::refresh_hidden_snapped_window(&window);
+            }
+        }
     }
 
     if remember_window_size_disabled {

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -455,7 +455,7 @@ mod tests {
     // 否则持久化 hide=false/hover=true 违规组合,下次开启 hide 时意外弹出触发条。
     // 注意:此测试只覆盖 normalize 本身的语义(单元级),
     // 端到端护栏(确认 set_edge_hide_enabled 函数体内真的调了 normalize)
-    // 在 tdd_tests.rs 的 set_edge_hide_enabled_calls_normalize_in_body。
+    // 在本模块内 set_edge_hide_enabled_calls_normalize_in_body。
     #[test]
     fn disabling_edge_hide_also_disables_hover() {
         let mut settings = AppSettings::default();
@@ -493,6 +493,29 @@ mod tests {
         normalize_edge_hover_invariant(&mut settings);
 
         assert!(!settings.edge_hover_popup_enabled, "开启贴边隐藏不强制开启悬浮弹出");
+    }
+
+    // 端到端护栏:set_edge_hide_enabled 函数体必须显式调用 normalize_edge_hover_invariant,
+    // 禁止直接 update_settings(settings) 跳过归一化。
+    // 源码字面存在性检查:即使函数无法在 lib test 中构造 AppHandle 调用,
+    // 也能确保回归保护不被未来改写绕过。
+    #[test]
+    fn set_edge_hide_enabled_calls_normalize_in_body() {
+        let source = include_str!("src-tauri/src/commands/settings.rs");
+        let start = source
+            .find("pub fn set_edge_hide_enabled")
+            .expect("找不到 set_edge_hide_enabled 定义");
+        let after = &source[start..];
+        let end_rel = after
+            .find("\n#[tauri::command]")
+            .or_else(|| after.find("\npub fn "))
+            .unwrap_or(after.len());
+        let body = &after[..end_rel];
+        assert!(
+            body.contains("normalize_edge_hover_invariant"),
+            "set_edge_hide_enabled 必须显式调用 normalize_edge_hover_invariant,\
+             禁止直接 update_settings(settings) 跳过归一化"
+        );
     }
 }
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -499,9 +499,14 @@ mod tests {
     // 禁止直接 update_settings(settings) 跳过归一化。
     // 源码字面存在性检查:即使函数无法在 lib test 中构造 AppHandle 调用,
     // 也能确保回归保护不被未来改写绕过。
+    // 运行时读源(include_str! 自指会编译期递归,不可用)。
     #[test]
     fn set_edge_hide_enabled_calls_normalize_in_body() {
-        let source = include_str!("src-tauri/src/commands/settings.rs");
+        let source = std::fs::read_to_string(format!(
+            "{}/src/commands/settings.rs",
+            env!("CARGO_MANIFEST_DIR")
+        ))
+        .expect("找不到 src/commands/settings.rs 源文件");
         let start = source
             .find("pub fn set_edge_hide_enabled")
             .expect("找不到 set_edge_hide_enabled 定义");

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -27,17 +27,12 @@ fn refresh_edge_hover_mode(app: &tauri::AppHandle) {
     if let Some(window) = app.get_webview_window("main") {
         let state = crate::windows::main_window::get_window_state();
         if state.is_snapped && state.is_hidden {
-            let settings = crate::get_settings();
-            // 悬浮开启时触发条需点击穿透(避免拦截边缘点击),关闭时窗口真隐藏无需穿透
-            let _ = window.set_ignore_cursor_events(settings.edge_hover_popup_enabled);
-            if settings.edge_hover_popup_enabled {
+            // 穿透/置顶/显隐的完整形态由 refresh_hidden_snapped_window 统一决策,
+            // 这里只需在开启分支先恢复可见,否则透明窗口 show 后触发条位置未刷新
+            if crate::get_settings().edge_hover_popup_enabled {
                 let _ = window.show();
-                let _ = window.set_always_on_top(true);
-                let _ = crate::windows::main_window::refresh_hidden_snapped_window(&window);
-            } else {
-                let _ = window.hide();
-                let _ = window.set_always_on_top(false);
             }
+            let _ = crate::windows::main_window::refresh_hidden_snapped_window(&window);
         }
     }
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -89,7 +89,7 @@ pub fn reload_settings() -> Result<AppSettings, String> {
 pub fn save_settings(mut settings: AppSettings, app: tauri::AppHandle) -> Result<(), String> {
     // 守不变量:贴边悬浮弹出蕴含贴边隐藏,JSON 导入或非 UI 流程若留下 hover=true/hide=false
     // 会在下次开启 hide 时意外弹出触发条 —— 此处一次性规范化
-    normalize_edge_hover_invariant(&mut settings);
+    settings.normalize_edge_hover_invariant();
 
     let old_settings = get_settings();
     let webdav_password = std::mem::take(&mut settings.webdav_password);
@@ -211,18 +211,11 @@ pub fn get_settings_cmd() -> AppSettings {
     get_settings()
 }
 
-// 守不变量:贴边悬浮弹出蕴含贴边隐藏。
-// 委托给 AppSettings::normalize_edge_hover_invariant,
-// 该方法是唯一决策点,load / JSON 导入路径也统一调用它。
-fn normalize_edge_hover_invariant(settings: &mut AppSettings) {
-    settings.normalize_edge_hover_invariant();
-}
-
 #[tauri::command]
 pub fn set_edge_hide_enabled(enabled: bool, app: tauri::AppHandle) -> Result<(), String> {
     let mut settings = get_settings();
     settings.edge_hide_enabled = enabled;
-    normalize_edge_hover_invariant(&mut settings);
+    settings.normalize_edge_hover_invariant();
 
     if !enabled {
         settings.edge_snap_position = None;
@@ -474,7 +467,7 @@ mod tests {
 
         // 模拟 set_edge_hide_enabled(false) 的写入路径
         settings.edge_hide_enabled = false;
-        normalize_edge_hover_invariant(&mut settings);
+        settings.normalize_edge_hover_invariant();
 
         assert!(!settings.edge_hover_popup_enabled, "关闭贴边隐藏必须同时关闭悬浮弹出");
     }
@@ -487,7 +480,7 @@ mod tests {
         settings.edge_hover_popup_enabled = true;
 
         settings.edge_hover_popup_enabled = false;
-        normalize_edge_hover_invariant(&mut settings);
+        settings.normalize_edge_hover_invariant();
 
         assert!(settings.edge_hide_enabled, "关闭悬浮弹出不得影响贴边隐藏");
     }
@@ -500,7 +493,7 @@ mod tests {
         settings.edge_hover_popup_enabled = false;
 
         settings.edge_hide_enabled = true;
-        normalize_edge_hover_invariant(&mut settings);
+        settings.normalize_edge_hover_invariant();
 
         assert!(!settings.edge_hover_popup_enabled, "开启贴边隐藏不强制开启悬浮弹出");
     }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -10,13 +10,33 @@ const DEFAULT_MAIN_WINDOW_HEIGHT: u32 = 520;
 fn handle_disable_edge_hide(app: &tauri::AppHandle) {
     if let Some(window) = app.get_webview_window("main") {
         let state = crate::windows::main_window::get_window_state();
-        
+
         if state.is_snapped {
             if state.is_hidden {
                 let _ = crate::windows::main_window::show_snapped_window(&window);
             }
             let _ = crate::windows::main_window::restore_from_snap(&window);
             crate::windows::main_window::stop_edge_monitoring();
+        }
+    }
+}
+
+// 切换"鼠标移到边缘弹出"开关后,若主窗口正处于贴边隐藏状态,立即刷新其形态:
+// 开启 -> 露出透明触发条(保持置顶);关闭 -> 真正隐藏,不留透明条
+fn refresh_edge_hover_mode(app: &tauri::AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        let state = crate::windows::main_window::get_window_state();
+        if state.is_snapped && state.is_hidden {
+            let settings = crate::get_settings();
+            let _ = window.set_ignore_cursor_events(!settings.edge_hover_popup_enabled);
+            if settings.edge_hover_popup_enabled {
+                let _ = window.show();
+                let _ = window.set_always_on_top(true);
+                let _ = crate::windows::main_window::refresh_hidden_snapped_window(&window);
+            } else {
+                let _ = window.hide();
+                let _ = window.set_always_on_top(false);
+            }
         }
     }
 }
@@ -92,6 +112,7 @@ pub fn save_settings(mut settings: AppSettings, app: tauri::AppHandle) -> Result
     settings.normalize_app_filter_blocklist();
     let clipboard_monitor_changed = old_settings.clipboard_monitor != settings.clipboard_monitor;
     let edge_hide_changed = old_settings.edge_hide_enabled != settings.edge_hide_enabled;
+    let edge_hover_changed = old_settings.edge_hover_popup_enabled != settings.edge_hover_popup_enabled;
     let quickpaste_enabled_changed = old_settings.quickpaste_enabled != settings.quickpaste_enabled;
     let remember_window_size_enabled =
         !old_settings.remember_window_size && settings.remember_window_size;
@@ -108,6 +129,10 @@ pub fn save_settings(mut settings: AppSettings, app: tauri::AppHandle) -> Result
         settings.edge_snap_ratio = None;
         settings.edge_snap_monitor_id = None;
         handle_disable_edge_hide(&app);
+    }
+
+    if edge_hover_changed {
+        refresh_edge_hover_mode(&app);
     }
 
     settings.update_check_interval = normalize_update_check_interval(&settings.update_check_interval);

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -89,9 +89,7 @@ pub fn reload_settings() -> Result<AppSettings, String> {
 pub fn save_settings(mut settings: AppSettings, app: tauri::AppHandle) -> Result<(), String> {
     // 守不变量:贴边悬浮弹出蕴含贴边隐藏,JSON 导入或非 UI 流程若留下 hover=true/hide=false
     // 会在下次开启 hide 时意外弹出触发条 —— 此处一次性规范化
-    if !settings.edge_hide_enabled {
-        settings.edge_hover_popup_enabled = false;
-    }
+    normalize_edge_hover_invariant(&mut settings);
 
     let old_settings = get_settings();
     let webdav_password = std::mem::take(&mut settings.webdav_password);
@@ -208,11 +206,21 @@ pub fn get_settings_cmd() -> AppSettings {
     get_settings()
 }
 
+// 守不变量:贴边悬浮弹出蕴含贴边隐藏。
+// 任何写入设置的非 UI 路径(set_edge_hide_enabled / JSON 导入 / save_settings)
+// 都必须调用此函数,否则会持久化 hover=true/hide=false 的违规组合。
+fn normalize_edge_hover_invariant(settings: &mut AppSettings) {
+    if !settings.edge_hide_enabled {
+        settings.edge_hover_popup_enabled = false;
+    }
+}
+
 #[tauri::command]
 pub fn set_edge_hide_enabled(enabled: bool, app: tauri::AppHandle) -> Result<(), String> {
     let mut settings = get_settings();
     settings.edge_hide_enabled = enabled;
-    
+    normalize_edge_hover_invariant(&mut settings);
+
     if !enabled {
         settings.edge_snap_position = None;
         settings.edge_snap_edge = None;
@@ -439,5 +447,51 @@ pub fn get_one_time_paste_enabled() -> bool {
 pub fn set_one_time_paste_enabled(enabled: bool) -> Result<bool, String> {
     crate::services::store::set(ONE_TIME_PASTE_STORE_KEY, &enabled)?;
     Ok(enabled)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // 回归:set_edge_hide_enabled(false) 必须连带关闭 hover,
+    // 否则持久化 hide=false/hover=true 违规组合,下次开启 hide 时意外弹出触发条
+    #[test]
+    fn disabling_edge_hide_also_disables_hover() {
+        let mut settings = AppSettings::default();
+        settings.edge_hide_enabled = true;
+        settings.edge_hover_popup_enabled = true;
+
+        // 模拟 set_edge_hide_enabled(false) 的写入路径
+        settings.edge_hide_enabled = false;
+        normalize_edge_hover_invariant(&mut settings);
+
+        assert!(!settings.edge_hover_popup_enabled, "关闭贴边隐藏必须同时关闭悬浮弹出");
+    }
+
+    // hover 蕴含 hide:仅关闭 hover 不影响 hide
+    #[test]
+    fn disabling_hover_keeps_edge_hide() {
+        let mut settings = AppSettings::default();
+        settings.edge_hide_enabled = true;
+        settings.edge_hover_popup_enabled = true;
+
+        settings.edge_hover_popup_enabled = false;
+        normalize_edge_hover_invariant(&mut settings);
+
+        assert!(settings.edge_hide_enabled, "关闭悬浮弹出不得影响贴边隐藏");
+    }
+
+    // 开启 hide 不强制开启 hover(用户偏好)
+    #[test]
+    fn enabling_edge_hide_keeps_hover_off() {
+        let mut settings = AppSettings::default();
+        settings.edge_hide_enabled = false;
+        settings.edge_hover_popup_enabled = false;
+
+        settings.edge_hide_enabled = true;
+        normalize_edge_hover_invariant(&mut settings);
+
+        assert!(!settings.edge_hover_popup_enabled, "开启贴边隐藏不强制开启悬浮弹出");
+    }
 }
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -124,7 +124,6 @@ pub fn save_settings(mut settings: AppSettings, app: tauri::AppHandle) -> Result
         settings.edge_snap_edge = None;
         settings.edge_snap_ratio = None;
         settings.edge_snap_monitor_id = None;
-        handle_disable_edge_hide(&app);
     }
 
     settings.update_check_interval = normalize_update_check_interval(&settings.update_check_interval);
@@ -138,6 +137,12 @@ pub fn save_settings(mut settings: AppSettings, app: tauri::AppHandle) -> Result
     }
 
     update_settings(settings.clone())?;
+
+    // §6 铁律 5:形态刷新必须在 update_settings 落地新值之后,
+    // 否则 handle_disable_edge_hide 读到旧 edge_hide_enabled=true 不会解开形态
+    if edge_hide_changed && !settings.edge_hide_enabled {
+        handle_disable_edge_hide(&app);
+    }
 
     if edge_hover_changed {
         // 新值已落地,再按新开关刷新贴边隐藏形态
@@ -224,10 +229,15 @@ pub fn set_edge_hide_enabled(enabled: bool, app: tauri::AppHandle) -> Result<(),
         settings.edge_snap_edge = None;
         settings.edge_snap_ratio = None;
         settings.edge_snap_monitor_id = None;
+    }
+
+    update_settings(settings)?;
+
+    // §6 铁律 5:形态刷新必须在 update_settings 落地新值之后
+    if !enabled {
         handle_disable_edge_hide(&app);
     }
-    
-    update_settings(settings)?;
+
     Ok(())
 }
 
@@ -520,6 +530,75 @@ mod tests {
             body.contains("normalize_edge_hover_invariant"),
             "set_edge_hide_enabled 必须显式调用 normalize_edge_hover_invariant,\
              禁止直接 update_settings(settings) 跳过归一化"
+        );
+    }
+
+    // §6 铁律 5 护栏:形态刷新必须在 update_settings 落地新值之后。
+    // save_settings 函数体内 handle_disable_edge_hide 必须在
+    // "update_settings(settings.clone())?;" 这一行之后。
+    // 当前实现若把 handle_disable_edge_hide 挪到 update_settings 之前,
+    // 读 get_settings().edge_hide_enabled 仍会拿到旧值,行为整体反转
+    // (与 6c197ee9 栽过的同类 footgun 同源)。
+    // 用更具体的代码片段锚点 "update_settings(settings.clone())?;"
+    // 避免函数名被注释误命中。
+    #[test]
+    fn save_settings_handle_disable_edge_hide_runs_after_update_settings() {
+        let source = std::fs::read_to_string(format!(
+            "{}/src/commands/settings.rs",
+            env!("CARGO_MANIFEST_DIR")
+        ))
+        .expect("找不到 src/commands/settings.rs 源文件");
+        let start = source
+            .find("pub fn save_settings")
+            .expect("找不到 save_settings 定义");
+        let after = &source[start..];
+        let end_rel = after
+            .find("\n#[tauri::command]")
+            .or_else(|| after.find("\npub fn "))
+            .unwrap_or(after.len());
+        let body = &after[..end_rel];
+        let update_pos = body
+            .find("update_settings(settings.clone())?;")
+            .expect("save_settings 体内必须先有 update_settings(settings.clone())?; 锚点");
+        let disable_pos = body
+            .find("handle_disable_edge_hide(&app);")
+            .expect("save_settings 体内必须出现 handle_disable_edge_hide(&app); 调用");
+        assert!(
+            disable_pos > update_pos,
+            "save_settings 体内 handle_disable_edge_hide 必须在 update_settings 之后,\
+             违反 §6 铁律 5(形态刷新落地新值之后)"
+        );
+    }
+
+    // §6 铁律 5 护栏:set_edge_hide_enabled 函数体内同样必须遵循
+    // update_settings 先于 handle_disable_edge_hide。
+    // 用具体代码片段锚点避免注释误命中。
+    #[test]
+    fn set_edge_hide_enabled_handle_disable_edge_hide_runs_after_update_settings() {
+        let source = std::fs::read_to_string(format!(
+            "{}/src/commands/settings.rs",
+            env!("CARGO_MANIFEST_DIR")
+        ))
+        .expect("找不到 src/commands/settings.rs 源文件");
+        let start = source
+            .find("pub fn set_edge_hide_enabled")
+            .expect("找不到 set_edge_hide_enabled 定义");
+        let after = &source[start..];
+        let end_rel = after
+            .find("\n#[tauri::command]")
+            .or_else(|| after.find("\npub fn "))
+            .unwrap_or(after.len());
+        let body = &after[..end_rel];
+        let update_pos = body
+            .find("update_settings(settings)?;")
+            .expect("set_edge_hide_enabled 体内必须先有 update_settings(settings)?; 锚点");
+        let disable_pos = body
+            .find("handle_disable_edge_hide(&app);")
+            .expect("set_edge_hide_enabled 体内必须出现 handle_disable_edge_hide(&app); 调用");
+        assert!(
+            disable_pos > update_pos,
+            "set_edge_hide_enabled 体内 handle_disable_edge_hide 必须在 update_settings 之后,\
+             违反 §6 铁律 5(形态刷新落地新值之后)"
         );
     }
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -452,7 +452,10 @@ mod tests {
     use super::*;
 
     // 回归:set_edge_hide_enabled(false) 必须连带关闭 hover,
-    // 否则持久化 hide=false/hover=true 违规组合,下次开启 hide 时意外弹出触发条
+    // 否则持久化 hide=false/hover=true 违规组合,下次开启 hide 时意外弹出触发条。
+    // 注意:此测试只覆盖 normalize 本身的语义(单元级),
+    // 端到端护栏(确认 set_edge_hide_enabled 函数体内真的调了 normalize)
+    // 在 tdd_tests.rs 的 set_edge_hide_enabled_calls_normalize_in_body。
     #[test]
     fn disabling_edge_hide_also_disables_hover() {
         let mut settings = AppSettings::default();

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -207,12 +207,10 @@ pub fn get_settings_cmd() -> AppSettings {
 }
 
 // 守不变量:贴边悬浮弹出蕴含贴边隐藏。
-// 任何写入设置的非 UI 路径(set_edge_hide_enabled / JSON 导入 / save_settings)
-// 都必须调用此函数,否则会持久化 hover=true/hide=false 的违规组合。
+// 委托给 AppSettings::normalize_edge_hover_invariant,
+// 该方法是唯一决策点,load / JSON 导入路径也统一调用它。
 fn normalize_edge_hover_invariant(settings: &mut AppSettings) {
-    if !settings.edge_hide_enabled {
-        settings.edge_hover_popup_enabled = false;
-    }
+    settings.normalize_edge_hover_invariant();
 }
 
 #[tauri::command]

--- a/src-tauri/src/services/data_management/mod.rs
+++ b/src-tauri/src/services/data_management/mod.rs
@@ -319,6 +319,9 @@ pub fn import_data_zip(zip_path: PathBuf, mode: &str) -> Result<String, String> 
             } else {
                 get_settings()
             };
+            // 守不变量:导入的 settings.json 可能带 hide=false/hover=true 违规组合,
+            // 落地前统一归一化,防止下次开启 hide 时意外弹出触发条
+            new_settings.normalize_edge_hover_invariant();
             if crate::services::is_portable_build() || std::env::current_exe().ok().and_then(|e| e.parent().map(|p| p.join("portable.txt").exists())).unwrap_or(false) {
                 new_settings.use_custom_storage = false;
                 new_settings.custom_storage_path = None;

--- a/src-tauri/src/services/settings/model.rs
+++ b/src-tauri/src/services/settings/model.rs
@@ -457,4 +457,30 @@ mod tests {
         assert!(settings.app_filter_list.is_empty());
         assert_eq!(settings.app_filter_mode, "blacklist");
     }
+
+    // 归一化:hide=false ⇒ hover=false
+    #[test]
+    fn edge_hover_invariant_holds_when_hide_disabled() {
+        let mut settings = AppSettings::default();
+        settings.edge_hide_enabled = false;
+        settings.edge_hover_popup_enabled = true;
+        settings.normalize_edge_hover_invariant();
+        assert!(
+            !settings.edge_hover_popup_enabled,
+            "edge_hide_enabled=false 必须蕴含 hover=false"
+        );
+    }
+
+    // 归一化方向:hide=true 不蕴含 hover=true,保留用户偏好
+    #[test]
+    fn edge_hover_invariant_keeps_hover_off_when_hide_enabled() {
+        let mut settings = AppSettings::default();
+        settings.edge_hide_enabled = true;
+        settings.edge_hover_popup_enabled = false;
+        settings.normalize_edge_hover_invariant();
+        assert!(
+            !settings.edge_hover_popup_enabled,
+            "开启 hide 不强制开启 hover"
+        );
+    }
 }

--- a/src-tauri/src/services/settings/model.rs
+++ b/src-tauri/src/services/settings/model.rs
@@ -395,7 +395,7 @@ impl AppSettings {
     // 任何写入设置的非 UI 路径(load / JSON 导入 / save_settings / set_edge_hide_enabled)
     // 都必须调用此方法,否则会持久化 hover=true/hide=false 的违规组合,
     // 下次开启 hide 时意外弹出触发条。
-    // 反向不蕴含:hide=true 不会自动打开 hover,保留用户上次偏好(默认 off)——产品决策。
+    // 反向不蕴含:hide=true 不会自动打开 hover,保留用户上次偏好——产品决策。
     pub fn normalize_edge_hover_invariant(&mut self) {
         if !self.edge_hide_enabled {
             self.edge_hover_popup_enabled = false;

--- a/src-tauri/src/services/settings/model.rs
+++ b/src-tauri/src/services/settings/model.rs
@@ -137,6 +137,7 @@ pub struct AppSettings {
 
     // 贴边隐藏设置
     pub edge_hide_enabled: bool,
+    pub edge_hover_popup_enabled: bool,
     pub edge_snap_position: Option<(i32, i32)>,
     pub edge_snap_edge: Option<String>,
     pub edge_snap_ratio: Option<f64>,
@@ -326,6 +327,7 @@ impl Default for AppSettings {
             saved_window_size: None,
 
             edge_hide_enabled: true,
+            edge_hover_popup_enabled: true,
             edge_snap_position: None,
             edge_snap_edge: None,
             edge_snap_ratio: None,

--- a/src-tauri/src/services/settings/model.rs
+++ b/src-tauri/src/services/settings/model.rs
@@ -391,6 +391,16 @@ impl Default for AppSettings {
 }
 
 impl AppSettings {
+    // 守不变量:贴边悬浮弹出蕴含贴边隐藏。
+    // 任何写入设置的非 UI 路径(load / JSON 导入 / save_settings / set_edge_hide_enabled)
+    // 都必须调用此方法,否则会持久化 hover=true/hide=false 的违规组合,
+    // 下次开启 hide 时意外弹出触发条。
+    pub fn normalize_edge_hover_invariant(&mut self) {
+        if !self.edge_hide_enabled {
+            self.edge_hover_popup_enabled = false;
+        }
+    }
+
     pub fn normalize_app_filter_blocklist(&mut self) -> bool {
         let mut changed = false;
 

--- a/src-tauri/src/services/settings/model.rs
+++ b/src-tauri/src/services/settings/model.rs
@@ -391,10 +391,11 @@ impl Default for AppSettings {
 }
 
 impl AppSettings {
-    // 守不变量:贴边悬浮弹出蕴含贴边隐藏。
+    // 守不变量:贴边悬浮弹出蕴含贴边隐藏(单箭头,非双向)。
     // 任何写入设置的非 UI 路径(load / JSON 导入 / save_settings / set_edge_hide_enabled)
     // 都必须调用此方法,否则会持久化 hover=true/hide=false 的违规组合,
     // 下次开启 hide 时意外弹出触发条。
+    // 反向不蕴含:hide=true 不会自动打开 hover,保留用户上次偏好(默认 off)——产品决策。
     pub fn normalize_edge_hover_invariant(&mut self) {
         if !self.edge_hide_enabled {
             self.edge_hover_popup_enabled = false;

--- a/src-tauri/src/services/settings/state.rs
+++ b/src-tauri/src/services/settings/state.rs
@@ -23,6 +23,9 @@ where
 {
     let mut settings = SETTINGS.write();
     updater(&mut settings);
+    // 守不变量:update_with 是与 update_settings 并列的写入入口,
+    // 必须共享归一化,杜绝 hide=false/hover=true 违规组合落地
+    settings.normalize_edge_hover_invariant();
     SettingsStorage::save(&settings)
 }
 

--- a/src-tauri/src/services/settings/state.rs
+++ b/src-tauri/src/services/settings/state.rs
@@ -33,3 +33,51 @@ pub fn get_data_directory() -> Result<std::path::PathBuf, String> {
     let settings = SETTINGS.read();
     SettingsStorage::get_data_directory(&settings)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // update_settings(所有写入统一入口)必须执行归一化
+    #[test]
+    fn update_settings_normalizes_edge_hover_invariant() {
+        let mut settings = AppSettings::default();
+        settings.edge_hide_enabled = false;
+        settings.edge_hover_popup_enabled = true;
+        update_settings(settings.clone()).unwrap();
+        let loaded = get_settings();
+        assert!(
+            !loaded.edge_hover_popup_enabled,
+            "update_settings 必须归一化,杜绝 hide=false/hover=true 落地"
+        );
+        // 恢复默认,避免污染其他测试
+        update_settings(AppSettings::default()).unwrap();
+    }
+
+    // update_with 也必须与 update_settings 共享归一化
+    #[test]
+    fn update_with_normalizes_edge_hover_invariant() {
+        let mut seed = AppSettings::default();
+        seed.edge_hide_enabled = true;
+        seed.edge_hover_popup_enabled = true;
+        update_settings(seed).unwrap();
+
+        update_with(|s| {
+            s.edge_hide_enabled = false;
+        })
+        .expect("update_with 必须支持 hide 字段变更");
+
+        let loaded = get_settings();
+        assert!(
+            !loaded.edge_hover_popup_enabled,
+            "update_with 必须归一化 hide=false ⇒ hover=false,现状 hover={}",
+            loaded.edge_hover_popup_enabled
+        );
+        assert!(
+            !loaded.edge_hide_enabled,
+            "update_with 应保留 hide=false 写入"
+        );
+
+        update_settings(AppSettings::default()).unwrap();
+    }
+}

--- a/src-tauri/src/services/settings/state.rs
+++ b/src-tauri/src/services/settings/state.rs
@@ -37,10 +37,21 @@ pub fn get_data_directory() -> Result<std::path::PathBuf, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // 串行化所有写 SETTINGS 的测试。
+    // 否则并发跑时 update_settings / update_with 互相覆盖,
+    // 读到对方刚写入的 hide=true/hover=true,误判归一化失败。
+    static SERIAL: Mutex<()> = Mutex::new(());
+
+    fn lock_serial() -> std::sync::MutexGuard<'static, ()> {
+        SERIAL.lock().unwrap_or_else(|e| e.into_inner())
+    }
 
     // update_settings(所有写入统一入口)必须执行归一化
     #[test]
     fn update_settings_normalizes_edge_hover_invariant() {
+        let _g = lock_serial();
         let mut settings = AppSettings::default();
         settings.edge_hide_enabled = false;
         settings.edge_hover_popup_enabled = true;
@@ -57,6 +68,7 @@ mod tests {
     // update_with 也必须与 update_settings 共享归一化
     #[test]
     fn update_with_normalizes_edge_hover_invariant() {
+        let _g = lock_serial();
         let mut seed = AppSettings::default();
         seed.edge_hide_enabled = true;
         seed.edge_hover_popup_enabled = true;

--- a/src-tauri/src/services/settings/state.rs
+++ b/src-tauri/src/services/settings/state.rs
@@ -10,7 +10,9 @@ pub fn get_settings() -> AppSettings {
     SETTINGS.read().clone()
 }
 
-pub fn update_settings(settings: AppSettings) -> Result<(), String> {
+pub fn update_settings(mut settings: AppSettings) -> Result<(), String> {
+    // 守不变量:所有写入路径统一入口,杜绝 hide=false/hover=true 违规组合落地
+    settings.normalize_edge_hover_invariant();
     *SETTINGS.write() = settings.clone();
     SettingsStorage::save(&settings)
 }

--- a/src-tauri/src/services/settings/storage.rs
+++ b/src-tauri/src/services/settings/storage.rs
@@ -87,6 +87,9 @@ impl SettingsStorage {
             }
             settings.webdav_password.clear();
         }
+        // 守不变量:手改/旧 JSON 可能留下 hide=false/hover=true 违规组合,
+        // 加载时统一归一化,防止下次开启 hide 时意外弹出触发条
+        settings.normalize_edge_hover_invariant();
         let normalized = settings.normalize_app_filter_blocklist();
         let migrated = Self::migrate_settings(&mut settings)
             || normalized

--- a/src-tauri/src/windows/main_window/edge_monitor.rs
+++ b/src-tauri/src/windows/main_window/edge_monitor.rs
@@ -77,8 +77,10 @@ pub fn start_edge_monitoring() {
             }
 
             // 鼠标悬浮弹出开关:关闭后既不自动弹出,也不自动收回,
-            // 窗口显隐完全由快捷键/托盘等显式操作控制
+            // 窗口显隐完全由快捷键/托盘等显式操作控制。
+            // last_near 置 false:重新开启时若鼠标已在触发区,能走 false→true 弹出
             if !crate::get_settings().edge_hover_popup_enabled {
+                last_near_state = false;
                 std::thread::sleep(Duration::from_millis(50));
                 continue;
             }

--- a/src-tauri/src/windows/main_window/edge_monitor.rs
+++ b/src-tauri/src/windows/main_window/edge_monitor.rs
@@ -64,6 +64,13 @@ pub fn start_edge_monitoring() {
                 std::thread::sleep(Duration::from_millis(100));
                 continue;
             }
+
+            // 鼠标悬浮弹出开关:关闭后既不自动弹出,也不自动收回,
+            // 窗口显隐完全由快捷键/托盘等显式操作控制
+            if !crate::get_settings().edge_hover_popup_enabled {
+                std::thread::sleep(Duration::from_millis(50));
+                continue;
+            }
  
             if last_hidden_state != state.is_hidden {
                 last_hidden_state = state.is_hidden;

--- a/src-tauri/src/windows/main_window/edge_monitor.rs
+++ b/src-tauri/src/windows/main_window/edge_monitor.rs
@@ -65,18 +65,20 @@ pub fn start_edge_monitoring() {
                 continue;
             }
 
-            // 鼠标悬浮弹出开关:关闭后既不自动弹出,也不自动收回,
-            // 窗口显隐完全由快捷键/托盘等显式操作控制
-            if !crate::get_settings().edge_hover_popup_enabled {
-                std::thread::sleep(Duration::from_millis(50));
-                continue;
-            }
- 
+            // 显隐状态变化时,重同步鼠标近边状态,
+            // 避免窗口由显式操作(快捷键/托盘)显隐后状态机误判
             if last_hidden_state != state.is_hidden {
                 last_hidden_state = state.is_hidden;
                 if let Ok(is_near) = check_mouse_near_edge(&window, &state) {
                     last_near_state = is_near;
                 }
+                std::thread::sleep(Duration::from_millis(50));
+                continue;
+            }
+
+            // 鼠标悬浮弹出开关:关闭后既不自动弹出,也不自动收回,
+            // 窗口显隐完全由快捷键/托盘等显式操作控制
+            if !crate::get_settings().edge_hover_popup_enabled {
                 std::thread::sleep(Duration::from_millis(50));
                 continue;
             }

--- a/src-tauri/src/windows/main_window/snap.rs
+++ b/src-tauri/src/windows/main_window/snap.rs
@@ -841,7 +841,9 @@ fn begin_animation() -> u64 {
 }
 
 // post-animation 刷新共享在飞动画的版本,不 bump。
-// 只有 cancel_pending_animation(同步形态决策)才会 bump,让动画与 post-refresh 一起失效。
+// begin_animation 独占初始 bump(同批动画首次 spawn 时 fetch_add 取走当前版本),
+// cancel_pending_animation(同步形态决策)可 bump 让在飞动画与 post-refresh 一起失效;
+// 本函数仅 load 共享,不 bump。
 fn share_animation_version() -> u64 {
     ANIMATION_VERSION.load(Ordering::SeqCst)
 }

--- a/src-tauri/src/windows/main_window/snap.rs
+++ b/src-tauri/src/windows/main_window/snap.rs
@@ -1003,4 +1003,78 @@ mod tests {
             "cancel 后动画必须失效"
         );
     }
+
+    // #1 show 取消在飞 hide 动画:show_snapped_window 必须 cancel_pending_animation
+    // 使 hide 动画/延迟 refresh 失效,避免过期任务用过期设置改写形态
+    #[test]
+    fn show_cancels_in_flight_hide_animation_session() {
+        let hide_animation_version = begin_animation();
+        cancel_pending_animation();
+        assert_ne!(
+            hide_animation_version,
+            share_animation_version(),
+            "show 必须使在飞 hide 动画失效"
+        );
+        let show_animation_version = begin_animation();
+        assert_eq!(
+            show_animation_version,
+            share_animation_version(),
+            "show 动画取到的新版本必须与全局一致"
+        );
+    }
+
+    // #2 show 动画 begin 自身 bump 兜底:即使 show 未显式 cancel,
+    // begin_animation 也会 bump 版本,使 hide 动画线程下一帧自杀
+    #[test]
+    fn show_animation_bump_invalidates_in_flight_hide() {
+        let hide_version = begin_animation();
+        let show_version = begin_animation();
+        assert_ne!(hide_version, show_version, "show 动画必须使 hide 动画失效");
+        assert_eq!(
+            show_version,
+            share_animation_version(),
+            "show 动画自己必须存活"
+        );
+    }
+
+    // #3 hide 动画条件仅由 clipboard_animation_enabled 决定,
+    // hover 关闭不得跳过滑出动画
+    #[test]
+    fn hide_animation_condition_depends_only_on_clipboard_animation() {
+        let settings = crate::services::settings::get_settings();
+        let should_animate = settings.clipboard_animation_enabled;
+        let _hover_enabled = settings.edge_hover_popup_enabled;
+        assert!(
+            should_animate,
+            "动画条件应仅由 clipboard_animation_enabled 决定"
+        );
+    }
+
+    // #4 show 路径顺序:set_position 必须先于 set_ignore_cursor_events(false)
+    // 与 refresh 唯一决策点对齐,避免中间窗口在屏外坐标短暂可点击
+    #[test]
+    fn show_path_set_position_precedes_ignore_cursor_false() {
+        let source = include_str!("src-tauri/src/windows/main_window/snap.rs");
+        let show_start = source
+            .find("pub fn show_snapped_window")
+            .expect("找不到 show_snapped_window 定义");
+        let after = &source[show_start..];
+        let show_end_rel = after
+            .find("\npub fn ")
+            .or_else(|| after.find("\nfn "))
+            .unwrap_or(after.len());
+        let show_body = &after[..show_end_rel];
+        let pos_ignore_off = show_body
+            .find("set_ignore_cursor_events(false)")
+            .expect("show 路径未发现 set_ignore_cursor_events(false) 调用");
+        let pos_set_position = show_body
+            .find("set_position")
+            .expect("show 路径未发现 set_position 调用");
+        assert!(
+            pos_set_position < pos_ignore_off,
+            "show 路径必须先 set_position 再 set_ignore_cursor_events(false)。\
+             当前 set_position 位于第 {} 字符,set_ignore_cursor_events(false) 位于第 {} 字符",
+            pos_set_position, pos_ignore_off
+        );
+    }
 }

--- a/src-tauri/src/windows/main_window/snap.rs
+++ b/src-tauri/src/windows/main_window/snap.rs
@@ -1,5 +1,5 @@
 use tauri::{WebviewWindow, Manager, Emitter};
-use super::state::{SnapEdge, set_snap_edge, set_hidden, clear_snap, is_snapped};
+use super::state::{SnapEdge, set_snap_edge, set_hidden, set_hidden_and_window_state, clear_snap, is_snapped};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
@@ -22,7 +22,7 @@ fn schedule_post_animation_refresh(
     app: tauri::AppHandle,
     delay_ms: u64,
 ) -> Result<(), String> {
-    let version = ANIMATION_VERSION.fetch_add(1, Ordering::SeqCst) + 1;
+    let version = share_animation_version();
     std::thread::spawn(move || {
         std::thread::sleep(Duration::from_millis(delay_ms));
         if ANIMATION_VERSION.load(Ordering::SeqCst) != version {
@@ -576,9 +576,8 @@ pub fn hide_snapped_window(window: &WebviewWindow) -> Result<(), String> {
         Some(resolved.monitor_id.clone()),
         Some(ratio),
     );
-    set_hidden(true);
+    set_hidden_and_window_state(true, super::state::WindowState::Hidden);
     save_snap_layout(resolved.edge, ratio, Some(resolved.monitor_id));
-    super::state::set_window_state(super::state::WindowState::Hidden);
 
     // 形态决策(穿透/置顶/显隐)全部交给 refresh_hidden_snapped_window 唯一决策点
     // 动画分支:先滑到屏外坐标,延迟 200ms 再 refresh,避免半屏状态被穿透导致触发条闪一下
@@ -764,10 +763,8 @@ pub fn show_snapped_window(window: &WebviewWindow) -> Result<(), String> {
         Some(resolved.monitor_id.clone()),
         Some(ratio),
     );
-    set_hidden(false);
+    set_hidden_and_window_state(false, super::state::WindowState::Visible);
     save_snap_layout(resolved.edge, ratio, Some(resolved.monitor_id));
-    
-    super::state::set_window_state(super::state::WindowState::Visible);
     crate::services::webdav_sync::notify_main_window_shown(window.app_handle().clone());
     let _ = super::refresh_always_on_top(window);
 
@@ -775,6 +772,17 @@ pub fn show_snapped_window(window: &WebviewWindow) -> Result<(), String> {
     crate::input_monitor::enable_navigation_keys();
     
     Ok(())
+}
+
+// 动画开始:独占一次 bump,取走当前版本。同一批动画后续的 post-refresh 不得再 bump。
+fn begin_animation() -> u64 {
+    ANIMATION_VERSION.fetch_add(1, Ordering::SeqCst) + 1
+}
+
+// post-animation 刷新共享在飞动画的版本,不 bump。
+// 只有 cancel_pending_animation(同步形态决策)才会 bump,让动画与 post-refresh 一起失效。
+fn share_animation_version() -> u64 {
+    ANIMATION_VERSION.load(Ordering::SeqCst)
 }
 
 fn animate_window_position(
@@ -785,7 +793,7 @@ fn animate_window_position(
     end_y: i32,
     duration_ms: u64,
 ) -> Result<(), String> {
-    let version = ANIMATION_VERSION.fetch_add(1, Ordering::SeqCst) + 1;
+    let version = begin_animation();
     let window_clone = window.clone();
     let app = window.app_handle().clone();
     
@@ -892,9 +900,8 @@ pub fn restore_edge_snap_on_startup(window: &WebviewWindow) -> Result<(), String
         Some(resolved.monitor_id.clone()),
         Some(snapped_ratio),
     );
-    set_hidden(true);
+    set_hidden_and_window_state(true, super::state::WindowState::Hidden);
     save_snap_layout(resolved.edge, snapped_ratio, Some(resolved.monitor_id));
-    super::state::set_window_state(super::state::WindowState::Hidden);
 
     // 形态决策(穿透/置顶/显隐)交给 refresh,与其他隐藏路径保持一致
     refresh_hidden_snapped_window(window)?;
@@ -906,4 +913,39 @@ pub fn restore_edge_snap_on_startup(window: &WebviewWindow) -> Result<(), String
     super::edge_monitor::start_edge_monitoring();
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // 回归测试:隐藏动画与 post-animation 刷新必须共享同一版本号。
+    // 原实现两者各自 fetch_add,动画线程第一帧因版本不匹配即自杀,滑出动画一帧不播。
+    #[test]
+    fn post_animation_refresh_shares_version_with_in_flight_animation() {
+        let animation_version = begin_animation();
+        let post_refresh_version = share_animation_version();
+        assert_eq!(
+            animation_version,
+            post_refresh_version,
+            "post-refresh 必须共享在飞动画的版本,不得再次 bump"
+        );
+        assert_eq!(
+            animation_version,
+            ANIMATION_VERSION.load(Ordering::SeqCst),
+            "动画版本必须等于全局版本,动画第一帧才不会被取消"
+        );
+    }
+
+    // cancel(同步形态决策)必须 bump 版本,让在飞动画与 post-refresh 都失效
+    #[test]
+    fn cancel_pending_animation_invalidates_in_flight_animation() {
+        let animation_version = begin_animation();
+        cancel_pending_animation();
+        assert_ne!(
+            animation_version,
+            ANIMATION_VERSION.load(Ordering::SeqCst),
+            "cancel 后动画必须失效"
+        );
+    }
 }

--- a/src-tauri/src/windows/main_window/snap.rs
+++ b/src-tauri/src/windows/main_window/snap.rs
@@ -11,14 +11,13 @@ static ANIMATION_VERSION: AtomicU64 = AtomicU64::new(0);
 // 决定 hide 路径是否走滑出动画。抽成纯函数便于 #[cfg(test)] 直接断言,
 // 防止未来有人在条件里塞入 `edge_hover_popup_enabled` 之类导致 hover 关闭时
 // 静默跳过滑出动画(4352887c 报告:动画条件仅由 clipboard_animation_enabled 决定)。
-pub(crate) fn should_play_hide_animation(settings: &crate::services::AppSettings) -> bool {
+fn should_play_hide_animation(settings: &crate::services::AppSettings) -> bool {
     settings.clipboard_animation_enabled
 }
 
 // bump 动画版本号:让正在等待的 post-animation 任务醒来后自行退出,
 // 避免用过期设置改写形态(发现 toggle 反转、半屏滑入点穿等)
-// pub(crate):同文件 #[cfg(test)] 模块需要直接验证版本语义
-pub(crate) fn cancel_pending_animation() {
+fn cancel_pending_animation() {
     ANIMATION_VERSION.fetch_add(1, Ordering::SeqCst);
 }
 

--- a/src-tauri/src/windows/main_window/snap.rs
+++ b/src-tauri/src/windows/main_window/snap.rs
@@ -635,9 +635,9 @@ pub fn refresh_hidden_snapped_window(window: &WebviewWindow) -> Result<(), Strin
     // 取消任何在飞的 post-animation 延迟任务,避免它用过期的设置改写形态
     cancel_pending_animation();
 
-    // 入口快照:若中途被并发 show 抢先改回 is_hidden=false,
-    // 尾部写入必须尊重,不得反手覆盖(否则 toggle 会反复走 hide 路径)
-    let entry_is_hidden = state.is_hidden;
+    // 尾部写入必须尊重并发 show:若中途被抢先 set_hidden_and_window_state(false, Visible),
+    // 跳过本次反手覆盖(否则 toggle 会反复走 hide 路径)。
+    // 入口早返已保证 state.is_hidden=true,只需 re-check 当前状态。
 
     let settings = crate::get_settings();
     let size = window.outer_size().map_err(|e| e.to_string())?;
@@ -697,7 +697,7 @@ pub fn refresh_hidden_snapped_window(window: &WebviewWindow) -> Result<(), Strin
     // is_hidden=true 但 state=Visible 的撕裂态(会误判 should_show)。
     // 写入前 re-check:若中途被并发 show 抢先 set_hidden_and_window_state(false, Visible),
     // 尊重对方的写入,跳过本路径的反手覆盖。
-    if entry_is_hidden && super::state::get_window_state().is_hidden {
+    if super::state::get_window_state().is_hidden {
         set_hidden_and_window_state(true, super::state::WindowState::Hidden);
     }
     save_snap_layout(resolved.edge, ratio, Some(resolved.monitor_id));

--- a/src-tauri/src/windows/main_window/snap.rs
+++ b/src-tauri/src/windows/main_window/snap.rs
@@ -542,14 +542,16 @@ pub fn hide_snapped_window(window: &WebviewWindow) -> Result<(), String> {
     // 不留任何透明条,彻底避免残留透明框拦截点击
     if !settings.edge_hover_popup_enabled {
         let _ = window.hide();
+        // 与悬浮开启分支保持一致:统一记录屏外隐藏位置,
+        // 避免同一隐藏状态两套坐标记账(屏上 vs 屏外)导致刷新漂移
         set_snap_edge(
-            state.snap_edge,
-            Some((x, y)),
-            state.snap_monitor_id.clone(),
-            state.snap_ratio,
+            resolved.edge,
+            Some((resolved.x, resolved.y)),
+            Some(resolved.monitor_id.clone()),
+            Some(ratio),
         );
         set_hidden(true);
-        save_snap_layout(state.snap_edge, state.snap_ratio.unwrap_or(0.5), state.snap_monitor_id.clone());
+        save_snap_layout(resolved.edge, ratio, Some(resolved.monitor_id));
         super::state::set_window_state(super::state::WindowState::Hidden);
         crate::services::memory::schedule_cleanup_after_main_window_hide();
         crate::input_monitor::disable_mouse_monitoring();
@@ -694,11 +696,6 @@ pub fn show_snapped_window(window: &WebviewWindow) -> Result<(), String> {
 
     // 显示时恢复鼠标事件捕获,确保窗口可交互
     let _ = window.set_ignore_cursor_events(false);
-
-    // 鼠标悬浮弹出开关关闭时,窗口用 hide() 真正隐藏,此处需先 show 再移动
-    if !settings.edge_hover_popup_enabled {
-        let _ = window.show();
-    }
 
     let ratio = state
         .snap_ratio
@@ -878,6 +875,8 @@ pub fn restore_edge_snap_on_startup(window: &WebviewWindow) -> Result<(), String
 
     if settings.edge_hover_popup_enabled {
         // 悬浮弹出开启:保持窗口可见(露出透明触发条),鼠标靠近即可弹出
+        // 触发条需点击穿透,避免透明区域拦截边缘点击
+        let _ = window.set_ignore_cursor_events(true);
         let _ = window.show();
         let _ = window.set_always_on_top(true);
     } else {

--- a/src-tauri/src/windows/main_window/snap.rs
+++ b/src-tauri/src/windows/main_window/snap.rs
@@ -1034,7 +1034,12 @@ mod tests {
 
         // 源码护栏:show_snapped_window 体内必须显式 cancel,
         // 且必须在原子写回 is_hidden=false 之前完成
-        let source = include_str!("src-tauri/src/windows/main_window/snap.rs");
+        // 运行时读源(include_str! 自指会编译期递归,不可用)
+        let source = std::fs::read_to_string(format!(
+            "{}/src/windows/main_window/snap.rs",
+            env!("CARGO_MANIFEST_DIR")
+        ))
+        .expect("找不到 src/windows/main_window/snap.rs 源文件");
         let show_start = source
             .find("pub fn show_snapped_window")
             .expect("找不到 show_snapped_window 定义");
@@ -1108,9 +1113,14 @@ mod tests {
 
     // #4 show 路径顺序:set_position 必须先于 set_ignore_cursor_events(false)
     // 与 refresh 唯一决策点对齐,避免中间窗口在屏外坐标短暂可点击
+    // 运行时读源(include_str! 自指会编译期递归,不可用)
     #[test]
     fn show_path_set_position_precedes_ignore_cursor_false() {
-        let source = include_str!("src-tauri/src/windows/main_window/snap.rs");
+        let source = std::fs::read_to_string(format!(
+            "{}/src/windows/main_window/snap.rs",
+            env!("CARGO_MANIFEST_DIR")
+        ))
+        .expect("找不到 src/windows/main_window/snap.rs 源文件");
         let show_start = source
             .find("pub fn show_snapped_window")
             .expect("找不到 show_snapped_window 定义");
@@ -1138,9 +1148,14 @@ mod tests {
     // show() 之后(因 show 抢焦点会清掉 WS_EX_TRANSPARENT),与 refresh 顺序对齐。
     // 复现条件:hover-on → 关闭态 → 快捷键/托盘唤出,hide 路径把 ignore 置 false 后
     // show 动画不重新打开穿透,半滑入时屏外坐标仍可被 raw_input 命中。
+    // 运行时读源(include_str! 自指会编译期递归,不可用)
     #[test]
     fn show_animation_branch_sets_ignore_true_before_show() {
-        let source = include_str!("src-tauri/src/windows/main_window/snap.rs");
+        let source = std::fs::read_to_string(format!(
+            "{}/src/windows/main_window/snap.rs",
+            env!("CARGO_MANIFEST_DIR")
+        ))
+        .expect("找不到 src/windows/main_window/snap.rs 源文件");
         let show_start = source
             .find("pub fn show_snapped_window")
             .expect("找不到 show_snapped_window 定义");
@@ -1163,7 +1178,7 @@ mod tests {
         let anim_branch_body = &anim_branch[..anim_branch_end];
 
         let pos_ignore_true = anim_branch_body
-            .find("set_ignore_cursor_events(true)")
+            .find("let _ = window.set_ignore_cursor_events(true);")
             .unwrap_or_else(|| {
                 panic!(
                     "show 动画分支必须显式 set_ignore_cursor_events(true),\

--- a/src-tauri/src/windows/main_window/snap.rs
+++ b/src-tauri/src/windows/main_window/snap.rs
@@ -40,6 +40,27 @@ fn schedule_post_animation_refresh(
     Ok(())
 }
 
+// 动画结束后写回 ignore=false(打开交互)。
+// show_snapped_window 在动画开启时必须保持穿透,等动画把窗口滑到屏上后再解锁,
+// 避免动画中段在屏外/中间坐标短暂可点。
+// 共享在飞动画版本,任何同步形态决策(cancel_pending_animation)会 bump 使本任务自杀。
+fn schedule_post_animation_set_interactive(
+    window: WebviewWindow,
+    app: tauri::AppHandle,
+    delay_ms: u64,
+) {
+    let version = share_animation_version();
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(delay_ms));
+        if ANIMATION_VERSION.load(Ordering::SeqCst) != version {
+            return;
+        }
+        let _ = app.run_on_main_thread(move || {
+            let _ = window.set_ignore_cursor_events(false);
+        });
+    });
+}
+
 #[derive(Clone, Debug)]
 struct MonitorEdgeContext {
     id: String,
@@ -607,6 +628,10 @@ pub fn refresh_hidden_snapped_window(window: &WebviewWindow) -> Result<(), Strin
     // 取消任何在飞的 post-animation 延迟任务,避免它用过期的设置改写形态
     cancel_pending_animation();
 
+    // 入口快照:若中途被并发 show 抢先改回 is_hidden=false,
+    // 尾部写入必须尊重,不得反手覆盖(否则 toggle 会反复走 hide 路径)
+    let entry_is_hidden = state.is_hidden;
+
     let settings = crate::get_settings();
     let size = window.outer_size().map_err(|e| e.to_string())?;
     let (x, y, _, _) = crate::utils::positioning::get_window_bounds(window)?;
@@ -662,8 +687,12 @@ pub fn refresh_hidden_snapped_window(window: &WebviewWindow) -> Result<(), Strin
         Some(ratio),
     );
     // 原子写 is_hidden + WindowState,避免与并发 toggle 交错时出现
-    // is_hidden=true 但 state=Visible 的撕裂态(会误判 should_show)
-    set_hidden_and_window_state(true, super::state::WindowState::Hidden);
+    // is_hidden=true 但 state=Visible 的撕裂态(会误判 should_show)。
+    // 写入前 re-check:若中途被并发 show 抢先 set_hidden_and_window_state(false, Visible),
+    // 尊重对方的写入,跳过本路径的反手覆盖。
+    if entry_is_hidden && super::state::get_window_state().is_hidden {
+        set_hidden_and_window_state(true, super::state::WindowState::Hidden);
+    }
     save_snap_layout(resolved.edge, ratio, Some(resolved.monitor_id));
 
     Ok(())
@@ -731,9 +760,6 @@ pub fn show_snapped_window(window: &WebviewWindow) -> Result<(), String> {
     let (x, y, _, _) = crate::utils::positioning::get_window_bounds(window)?;
     let settings = crate::get_settings();
 
-    // 显示时恢复鼠标事件捕获,确保窗口可交互
-    let _ = window.set_ignore_cursor_events(false);
-
     let ratio = state
         .snap_ratio
         .or(settings.edge_snap_ratio)
@@ -756,19 +782,33 @@ pub fn show_snapped_window(window: &WebviewWindow) -> Result<(), String> {
         size.width as i32,
         size.height as i32,
     )?;
-    
-    if !window.is_visible().unwrap_or(false) {
-        let _ = window.show();
-    }
-    let _ = window.emit("edge-snap-show", ());
-    let _ = crate::commands::window::emit_main_window_refresh_needed_event(&window.app_handle());
-    
-    // 根据动画配置决定是否使用过渡
+
+    // 顺序与 refresh 唯一决策点对齐:先落位(set_position)再打开交互(ignore=false),
+    // 最后 show。避免 set_ignore_cursor_events(false) 早于 set_position 导致
+    // 窗口短暂在屏外坐标变成可点击但不显示,被 raw_input / 无障碍 API 命中触发幽灵 click。
     if settings.clipboard_animation_enabled {
+        // 动画分支:animate 自带 set_position 逐步到位,期间必须保持穿透,
+        // 否则动画中段在屏外/中间坐标可点,被 raw_input 命中再次 hide。
+        // 动画结束后由 schedule_post_animation_set_interactive 写回 ignore=false。
+        if !window.is_visible().unwrap_or(false) {
+            let _ = window.show();
+        }
+        let _ = window.emit("edge-snap-show", ());
+        let _ = crate::commands::window::emit_main_window_refresh_needed_event(&window.app_handle());
         animate_window_position(window, x, y, resolved.x, resolved.y, 200)?;
+        schedule_post_animation_set_interactive(window.clone(), window.app_handle().clone(), 200);
     } else {
-        window.set_position(tauri::PhysicalPosition::new(resolved.x, resolved.y))
+        // 非动画分支:先 set_position 落到屏上,再打开交互,最后 show。
+        // 全程同步无中段,不会暴露屏外可点状态。
+        window
+            .set_position(tauri::PhysicalPosition::new(resolved.x, resolved.y))
             .map_err(|e| e.to_string())?;
+        let _ = window.set_ignore_cursor_events(false);
+        if !window.is_visible().unwrap_or(false) {
+            let _ = window.show();
+        }
+        let _ = window.emit("edge-snap-show", ());
+        let _ = crate::commands::window::emit_main_window_refresh_needed_event(&window.app_handle());
     }
     set_snap_edge(
         resolved.edge,

--- a/src-tauri/src/windows/main_window/snap.rs
+++ b/src-tauri/src/windows/main_window/snap.rs
@@ -538,36 +538,7 @@ pub fn hide_snapped_window(window: &WebviewWindow) -> Result<(), String> {
         settings.edge_hide_offset,
     )?;
 
-    // 关闭"鼠标移到边缘弹出"时,直接真正隐藏窗口,
-    // 不留任何透明条,彻底避免残留透明框拦截点击
-    if !settings.edge_hover_popup_enabled {
-        let _ = window.hide();
-        // 与悬浮开启分支保持一致:统一记录屏外隐藏位置,
-        // 避免同一隐藏状态两套坐标记账(屏上 vs 屏外)导致刷新漂移
-        set_snap_edge(
-            resolved.edge,
-            Some((resolved.x, resolved.y)),
-            Some(resolved.monitor_id.clone()),
-            Some(ratio),
-        );
-        set_hidden(true);
-        save_snap_layout(resolved.edge, ratio, Some(resolved.monitor_id));
-        super::state::set_window_state(super::state::WindowState::Hidden);
-        crate::services::memory::schedule_cleanup_after_main_window_hide();
-        crate::input_monitor::disable_mouse_monitoring();
-        crate::input_monitor::disable_navigation_keys();
-        return Ok(());
-    }
-
-    // 根据动画配置决定是否使用过渡
-    if settings.clipboard_animation_enabled {
-        animate_window_position(window, x, y, resolved.x, resolved.y, 200)?;
-    } else {
-        window.set_position(tauri::PhysicalPosition::new(resolved.x, resolved.y))
-            .map_err(|e| e.to_string())?;
-    }
-    // 隐藏状态让透明区域点击穿透,避免残留透明框拦截边缘点击
-    let _ = window.set_ignore_cursor_events(true);
+    // 先统一记账为屏外 resolved,形态(穿透/置顶/显隐)只交给 refresh
     set_snap_edge(
         resolved.edge,
         Some((resolved.x, resolved.y)),
@@ -576,10 +547,36 @@ pub fn hide_snapped_window(window: &WebviewWindow) -> Result<(), String> {
     );
     set_hidden(true);
     save_snap_layout(resolved.edge, ratio, Some(resolved.monitor_id));
-
     super::state::set_window_state(super::state::WindowState::Hidden);
-    crate::services::memory::schedule_cleanup_after_main_window_hide();
 
+    if !settings.edge_hover_popup_enabled {
+        // 关闭悬浮:真正 hide,不留触发条;形态走唯一决策点
+        refresh_hidden_snapped_window(window)?;
+    } else if settings.clipboard_animation_enabled {
+        // 滑入动画期间保持可点,动画结束后再穿透,避免半屏滑入时点穿
+        animate_window_position(window, x, y, resolved.x, resolved.y, 200)?;
+        let window_clone = window.clone();
+        let app = window.app_handle().clone();
+        let anim_version = ANIMATION_VERSION.load(Ordering::SeqCst);
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(200));
+            if ANIMATION_VERSION.load(Ordering::SeqCst) != anim_version {
+                return;
+            }
+            let _ = app.run_on_main_thread(move || {
+                if super::state::get_window_state().is_hidden {
+                    let _ = window_clone.set_ignore_cursor_events(true);
+                }
+            });
+        });
+    } else {
+        window
+            .set_position(tauri::PhysicalPosition::new(resolved.x, resolved.y))
+            .map_err(|e| e.to_string())?;
+        let _ = window.set_ignore_cursor_events(true);
+    }
+
+    crate::services::memory::schedule_cleanup_after_main_window_hide();
     crate::input_monitor::disable_mouse_monitoring();
     crate::input_monitor::disable_navigation_keys();
 
@@ -621,16 +618,17 @@ pub fn refresh_hidden_snapped_window(window: &WebviewWindow) -> Result<(), Strin
     )?;
 
     // 形态唯一决策点:穿透/置顶/显隐都按开关在此处统一刷新,
-    // 所有调用方(开关切换、显示器变更、恢复默认大小)行为一致
+    // 所有调用方(开关切换、显示器变更、恢复默认大小、hide)行为一致
     if settings.edge_hover_popup_enabled {
-        // 悬浮开启:露出透明触发条,保持置顶并点击穿透,避免拦截边缘点击
-        let _ = window.set_ignore_cursor_events(true);
+        // 悬浮开启:先 show/置顶/落点,最后再穿透(show 可能清扩展样式)
+        let _ = window.show();
         let _ = window.set_always_on_top(true);
         window
             .set_position(tauri::PhysicalPosition::new(resolved.x, resolved.y))
             .map_err(|e| e.to_string())?;
+        let _ = window.set_ignore_cursor_events(true);
     } else {
-        // 悬浮关闭:窗口已真正隐藏,取消置顶并恢复非穿透,保证形态状态一致
+        // 悬浮关闭:真正隐藏,取消置顶并恢复非穿透
         let _ = window.hide();
         let _ = window.set_always_on_top(false);
         let _ = window.set_ignore_cursor_events(false);
@@ -655,6 +653,11 @@ pub fn needs_hidden_snap_refresh(window: &WebviewWindow) -> Result<bool, String>
     }
 
     let settings = crate::get_settings();
+    // 真隐藏无触发条,OS 坐标与 state 屏外坐标本就不对齐,无需按位置刷
+    if !settings.edge_hover_popup_enabled {
+        return Ok(false);
+    }
+
     let size = window.outer_size().map_err(|e| e.to_string())?;
     let (x, y, _, _) = crate::utils::positioning::get_window_bounds(window)?;
     let ratio = state
@@ -881,15 +884,15 @@ pub fn restore_edge_snap_on_startup(window: &WebviewWindow) -> Result<(), String
     save_snap_layout(resolved.edge, snapped_ratio, Some(resolved.monitor_id));
 
     if settings.edge_hover_popup_enabled {
-        // 悬浮弹出开启:保持窗口可见(露出透明触发条),鼠标靠近即可弹出
-        // 触发条需点击穿透,避免透明区域拦截边缘点击
-        let _ = window.set_ignore_cursor_events(true);
+        // 悬浮开启:show/置顶后再写穿透,避免 show 清掉 WS_EX_TRANSPARENT
         let _ = window.show();
         let _ = window.set_always_on_top(true);
+        let _ = window.set_ignore_cursor_events(true);
     } else {
-        // 悬浮弹出关闭:直接真正隐藏,不留透明条
+        // 悬浮关闭:真正隐藏,并清掉置顶/穿透残留
         let _ = window.hide();
         let _ = window.set_always_on_top(false);
+        let _ = window.set_ignore_cursor_events(false);
     }
     
     super::state::set_window_state(super::state::WindowState::Hidden);

--- a/src-tauri/src/windows/main_window/snap.rs
+++ b/src-tauri/src/windows/main_window/snap.rs
@@ -10,7 +10,7 @@ static ANIMATION_VERSION: AtomicU64 = AtomicU64::new(0);
 
 // bump 动画版本号:让正在等待的 post-animation 任务醒来后自行退出,
 // 避免用过期设置改写形态(发现 toggle 反转、半屏滑入点穿等)
-// pub(crate):tdd_tests 需要直接验证版本语义
+// pub(crate):同文件 #[cfg(test)] 模块需要直接验证版本语义
 pub(crate) fn cancel_pending_animation() {
     ANIMATION_VERSION.fetch_add(1, Ordering::SeqCst);
 }
@@ -828,14 +828,14 @@ pub fn show_snapped_window(window: &WebviewWindow) -> Result<(), String> {
 }
 
 // 动画开始:独占一次 bump,取走当前版本。同一批动画后续的 post-refresh 不得再 bump。
-// pub(crate):tdd_tests 需要直接验证版本语义
+// pub(crate):同文件 #[cfg(test)] 模块需要直接验证版本语义
 pub(crate) fn begin_animation() -> u64 {
     ANIMATION_VERSION.fetch_add(1, Ordering::SeqCst) + 1
 }
 
 // post-animation 刷新共享在飞动画的版本,不 bump。
 // 只有 cancel_pending_animation(同步形态决策)才会 bump,让动画与 post-refresh 一起失效。
-// pub(crate):tdd_tests 需要直接验证版本语义
+// pub(crate):同文件 #[cfg(test)] 模块需要直接验证版本语义
 pub(crate) fn share_animation_version() -> u64 {
     ANIMATION_VERSION.load(Ordering::SeqCst)
 }

--- a/src-tauri/src/windows/main_window/snap.rs
+++ b/src-tauri/src/windows/main_window/snap.rs
@@ -837,15 +837,13 @@ pub fn show_snapped_window(window: &WebviewWindow) -> Result<(), String> {
 }
 
 // 动画开始:独占一次 bump,取走当前版本。同一批动画后续的 post-refresh 不得再 bump。
-// pub(crate):同文件 #[cfg(test)] 模块需要直接验证版本语义
-pub(crate) fn begin_animation() -> u64 {
+fn begin_animation() -> u64 {
     ANIMATION_VERSION.fetch_add(1, Ordering::SeqCst) + 1
 }
 
 // post-animation 刷新共享在飞动画的版本,不 bump。
 // 只有 cancel_pending_animation(同步形态决策)才会 bump,让动画与 post-refresh 一起失效。
-// pub(crate):同文件 #[cfg(test)] 模块需要直接验证版本语义
-pub(crate) fn share_animation_version() -> u64 {
+fn share_animation_version() -> u64 {
     ANIMATION_VERSION.load(Ordering::SeqCst)
 }
 

--- a/src-tauri/src/windows/main_window/snap.rs
+++ b/src-tauri/src/windows/main_window/snap.rs
@@ -8,6 +8,13 @@ const FRONTEND_CONTENT_INSET_LOGICAL: f64 = 5.0;
 
 static ANIMATION_VERSION: AtomicU64 = AtomicU64::new(0);
 
+// 决定 hide 路径是否走滑出动画。抽成纯函数便于 #[cfg(test)] 直接断言,
+// 防止未来有人在条件里塞入 `edge_hover_popup_enabled` 之类导致 hover 关闭时
+// 静默跳过滑出动画(4352887c 报告:动画条件仅由 clipboard_animation_enabled 决定)。
+pub(crate) fn should_play_hide_animation(settings: &crate::services::AppSettings) -> bool {
+    settings.clipboard_animation_enabled
+}
+
 // bump 动画版本号:让正在等待的 post-animation 任务醒来后自行退出,
 // 避免用过期设置改写形态(发现 toggle 反转、半屏滑入点穿等)
 // pub(crate):同文件 #[cfg(test)] 模块需要直接验证版本语义
@@ -603,8 +610,8 @@ pub fn hide_snapped_window(window: &WebviewWindow) -> Result<(), String> {
 
     // 形态决策(穿透/置顶/显隐)全部交给 refresh_hidden_snapped_window 唯一决策点
     // 动画分支:先滑到屏外坐标,延迟 200ms 再 refresh,避免半屏状态被穿透导致触发条闪一下
-    // 动画条件仅由 clipboard_animation_enabled 决定,不因 hover 关闭而跳过滑出动画
-    if settings.clipboard_animation_enabled {
+    // 动画条件由 should_play_hide_animation 决定,hover 关闭不跳过滑出动画
+    if should_play_hide_animation(&settings) {
         animate_window_position(window, x, y, resolved.x, resolved.y, 200)?;
         schedule_post_animation_refresh(window.clone(), window.app_handle().clone(), 200)?;
     } else {
@@ -789,10 +796,12 @@ pub fn show_snapped_window(window: &WebviewWindow) -> Result<(), String> {
     if settings.clipboard_animation_enabled {
         // 动画分支:animate 自带 set_position 逐步到位,期间必须保持穿透,
         // 否则动画中段在屏外/中间坐标可点,被 raw_input 命中再次 hide。
-        // 动画结束后由 schedule_post_animation_set_interactive 写回 ignore=false。
+        // 显式 set_ignore_cursor_events(true) 在 show 之后立即写,防止 show 抢焦点
+        // 后窗口在屏外坐标被点击截获;动画结束后由 schedule_post_animation_set_interactive 写回 false。
         if !window.is_visible().unwrap_or(false) {
             let _ = window.show();
         }
+        let _ = window.set_ignore_cursor_events(true);
         let _ = window.emit("edge-snap-show", ());
         let _ = crate::commands::window::emit_main_window_refresh_needed_event(&window.app_handle());
         animate_window_position(window, x, y, resolved.x, resolved.y, 200)?;
@@ -1008,6 +1017,7 @@ mod tests {
     // 使 hide 动画/延迟 refresh 失效,避免过期任务用过期设置改写形态
     #[test]
     fn show_cancels_in_flight_hide_animation_session() {
+        // 行为:版本号协调
         let hide_animation_version = begin_animation();
         cancel_pending_animation();
         assert_ne!(
@@ -1020,6 +1030,32 @@ mod tests {
             show_animation_version,
             share_animation_version(),
             "show 动画取到的新版本必须与全局一致"
+        );
+
+        // 源码护栏:show_snapped_window 体内必须显式 cancel,
+        // 且必须在原子写回 is_hidden=false 之前完成
+        let source = include_str!("src-tauri/src/windows/main_window/snap.rs");
+        let show_start = source
+            .find("pub fn show_snapped_window")
+            .expect("找不到 show_snapped_window 定义");
+        let after = &source[show_start..];
+        let show_end_rel = after
+            .find("\npub fn ")
+            .or_else(|| after.find("\nfn "))
+            .unwrap_or(after.len());
+        let show_body = &after[..show_end_rel];
+        let cancel_pos = show_body
+            .find("cancel_pending_animation()")
+            .expect("show_snapped_window 必须显式调用 cancel_pending_animation 取消在飞 hide 动画");
+        let set_hidden_pos = show_body
+            .find("set_hidden_and_window_state(false")
+            .expect("show_snapped_window 缺少原子写回 false");
+        assert!(
+            cancel_pos < set_hidden_pos,
+            "cancel 必须在 set_hidden_and_window_state(false, ...) 之前,\
+             否则 post-refresh 仍能用旧设置覆盖 show 形态(当前位置:cancel={}, set_hidden={})",
+            cancel_pos,
+            set_hidden_pos
         );
     }
 
@@ -1038,15 +1074,35 @@ mod tests {
     }
 
     // #3 hide 动画条件仅由 clipboard_animation_enabled 决定,
-    // hover 关闭不得跳过滑出动画
+    // hover 关闭不得跳过滑出动画(4352887c 修复)。
+    // 用纯函数直接断言,防止条件被人重新塞入 `edge_hover_popup_enabled` 之类。
     #[test]
     fn hide_animation_condition_depends_only_on_clipboard_animation() {
-        let settings = crate::services::settings::get_settings();
-        let should_animate = settings.clipboard_animation_enabled;
-        let _hover_enabled = settings.edge_hover_popup_enabled;
+        use crate::services::settings::AppSettings;
+        let mut s = AppSettings::default();
+        s.clipboard_animation_enabled = true;
+        s.edge_hover_popup_enabled = true;
         assert!(
-            should_animate,
-            "动画条件应仅由 clipboard_animation_enabled 决定"
+            should_play_hide_animation(&s),
+            "clipboard 开 + hover 开 ⇒ 应滑出动画"
+        );
+        s.edge_hover_popup_enabled = false;
+        assert!(
+            should_play_hide_animation(&s),
+            "hover 关闭不得影响 hide 动画(4352887c 行为)"
+        );
+        s.clipboard_animation_enabled = false;
+        assert!(
+            !should_play_hide_animation(&s),
+            "clipboard 动画关闭 ⇒ 不滑出"
+        );
+        // 反向断言:其它无关字段(start_hidden 等)不影响决定
+        s.clipboard_animation_enabled = true;
+        s.edge_hover_popup_enabled = true;
+        s.start_hidden = true;
+        assert!(
+            should_play_hide_animation(&s),
+            "start_hidden 等无关字段不得影响 hide 动画"
         );
     }
 
@@ -1075,6 +1131,57 @@ mod tests {
             "show 路径必须先 set_position 再 set_ignore_cursor_events(false)。\
              当前 set_position 位于第 {} 字符,set_ignore_cursor_events(false) 位于第 {} 字符",
             pos_set_position, pos_ignore_off
+        );
+    }
+
+    // #5 show 动画分支必须显式 set_ignore_cursor_events(true),且必须位于
+    // show() 之后(因 show 抢焦点会清掉 WS_EX_TRANSPARENT),与 refresh 顺序对齐。
+    // 复现条件:hover-on → 关闭态 → 快捷键/托盘唤出,hide 路径把 ignore 置 false 后
+    // show 动画不重新打开穿透,半滑入时屏外坐标仍可被 raw_input 命中。
+    #[test]
+    fn show_animation_branch_sets_ignore_true_before_show() {
+        let source = include_str!("src-tauri/src/windows/main_window/snap.rs");
+        let show_start = source
+            .find("pub fn show_snapped_window")
+            .expect("找不到 show_snapped_window 定义");
+        let after = &source[show_start..];
+        let show_end_rel = after
+            .find("\npub fn ")
+            .or_else(|| after.find("\nfn "))
+            .unwrap_or(after.len());
+        let show_body = &after[..show_end_rel];
+
+        // 截取动画分支体
+        let anim_branch_start = show_body
+            .find("clipboard_animation_enabled")
+            .expect("show 路径缺少动画分支判断");
+        let anim_branch = &show_body[anim_branch_start..];
+        // 动画分支以 } else { 或函数末尾结束
+        let anim_branch_end = anim_branch
+            .find("} else {")
+            .unwrap_or_else(|| anim_branch.find("\n    }").unwrap_or(anim_branch.len()));
+        let anim_branch_body = &anim_branch[..anim_branch_end];
+
+        let pos_ignore_true = anim_branch_body
+            .find("set_ignore_cursor_events(true)")
+            .unwrap_or_else(|| {
+                panic!(
+                    "show 动画分支必须显式 set_ignore_cursor_events(true),\
+                     否则 hover-on→关闭态→唤出 时半滑入坐标被点击截获。\
+                     当前动画分支体:\n{}",
+                    anim_branch_body
+                )
+            });
+        let pos_show = anim_branch_body
+            .find("window.show()")
+            .expect("show 动画分支缺少 window.show() 调用");
+        assert!(
+            pos_show < pos_ignore_true,
+            "show 动画分支必须先 show() 再 set_ignore_cursor_events(true),\
+             与 refresh 唯一决策点顺序对齐(避免 show 抢焦点清掉 WS_EX_TRANSPARENT)。\
+             当前 show={}, ignore=true={}",
+            pos_show,
+            pos_ignore_true
         );
     }
 }

--- a/src-tauri/src/windows/main_window/snap.rs
+++ b/src-tauri/src/windows/main_window/snap.rs
@@ -8,6 +8,37 @@ const FRONTEND_CONTENT_INSET_LOGICAL: f64 = 5.0;
 
 static ANIMATION_VERSION: AtomicU64 = AtomicU64::new(0);
 
+// bump 动画版本号:让正在等待的 post-animation 任务醒来后自行退出,
+// 避免用过期设置改写形态(发现 toggle 反转、半屏滑入点穿等)
+fn cancel_pending_animation() {
+    ANIMATION_VERSION.fetch_add(1, Ordering::SeqCst);
+}
+
+// 等待动画结束后调 refresh 重新写入形态;等待期间任何同步形态决策
+// (refresh_hidden_snapped_window / hide_snapped_window / restore_edge_snap_on_startup)
+// 都会再次 bump,本 task 醒来即自杀
+fn schedule_post_animation_refresh(
+    window: WebviewWindow,
+    app: tauri::AppHandle,
+    delay_ms: u64,
+) -> Result<(), String> {
+    let version = ANIMATION_VERSION.fetch_add(1, Ordering::SeqCst) + 1;
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(delay_ms));
+        if ANIMATION_VERSION.load(Ordering::SeqCst) != version {
+            return;
+        }
+        let state = super::state::get_window_state();
+        if !state.is_snapped || !state.is_hidden {
+            return;
+        }
+        let _ = app.run_on_main_thread(move || {
+            let _ = refresh_hidden_snapped_window(&window);
+        });
+    });
+    Ok(())
+}
+
 #[derive(Clone, Debug)]
 struct MonitorEdgeContext {
     id: String,
@@ -549,31 +580,13 @@ pub fn hide_snapped_window(window: &WebviewWindow) -> Result<(), String> {
     save_snap_layout(resolved.edge, ratio, Some(resolved.monitor_id));
     super::state::set_window_state(super::state::WindowState::Hidden);
 
-    if !settings.edge_hover_popup_enabled {
-        // 关闭悬浮:真正 hide,不留触发条;形态走唯一决策点
-        refresh_hidden_snapped_window(window)?;
-    } else if settings.clipboard_animation_enabled {
-        // 滑入动画期间保持可点,动画结束后再穿透,避免半屏滑入时点穿
+    // 形态决策(穿透/置顶/显隐)全部交给 refresh_hidden_snapped_window 唯一决策点
+    // 动画分支:先滑到屏外坐标,延迟 200ms 再 refresh,避免半屏状态被穿透导致触发条闪一下
+    if settings.edge_hover_popup_enabled && settings.clipboard_animation_enabled {
         animate_window_position(window, x, y, resolved.x, resolved.y, 200)?;
-        let window_clone = window.clone();
-        let app = window.app_handle().clone();
-        let anim_version = ANIMATION_VERSION.load(Ordering::SeqCst);
-        std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_millis(200));
-            if ANIMATION_VERSION.load(Ordering::SeqCst) != anim_version {
-                return;
-            }
-            let _ = app.run_on_main_thread(move || {
-                if super::state::get_window_state().is_hidden {
-                    let _ = window_clone.set_ignore_cursor_events(true);
-                }
-            });
-        });
+        schedule_post_animation_refresh(window.clone(), window.app_handle().clone(), 200)?;
     } else {
-        window
-            .set_position(tauri::PhysicalPosition::new(resolved.x, resolved.y))
-            .map_err(|e| e.to_string())?;
-        let _ = window.set_ignore_cursor_events(true);
+        refresh_hidden_snapped_window(window)?;
     }
 
     crate::services::memory::schedule_cleanup_after_main_window_hide();
@@ -589,6 +602,9 @@ pub fn refresh_hidden_snapped_window(window: &WebviewWindow) -> Result<(), Strin
     if !state.is_snapped || !state.is_hidden {
         return Ok(());
     }
+
+    // 取消任何在飞的 post-animation 延迟任务,避免它用过期的设置改写形态
+    cancel_pending_animation();
 
     let settings = crate::get_settings();
     let size = window.outer_size().map_err(|e| e.to_string())?;
@@ -617,20 +633,22 @@ pub fn refresh_hidden_snapped_window(window: &WebviewWindow) -> Result<(), Strin
         settings.edge_hide_offset,
     )?;
 
-    // 形态唯一决策点:穿透/置顶/显隐都按开关在此处统一刷新,
-    // 所有调用方(开关切换、显示器变更、恢复默认大小、hide)行为一致
+    // 形态唯一决策点:先落位再统一显隐/置顶/穿透
+    // set_position 必须先做,失败直接 return —— 避免出现停在屏外却已 show + 可点 的窗口
+    window
+        .set_position(tauri::PhysicalPosition::new(resolved.x, resolved.y))
+        .map_err(|e| e.to_string())?;
+
     if settings.edge_hover_popup_enabled {
-        // 悬浮开启:先 show/置顶/落点,最后再穿透(show 可能清扩展样式)
+        // 悬浮开启:触发条停留屏外但需保留可弹出,show 后立刻穿透,避免拦截边缘点击
         let _ = window.show();
         let _ = window.set_always_on_top(true);
-        window
-            .set_position(tauri::PhysicalPosition::new(resolved.x, resolved.y))
-            .map_err(|e| e.to_string())?;
         let _ = window.set_ignore_cursor_events(true);
     } else {
-        // 悬浮关闭:真正隐藏,取消置顶并恢复非穿透
+        // 悬浮关闭:真正 hide,清掉 WS_EX_TRANSPARENT 残影;
+        // 不动 set_always_on_top —— 用户置顶偏好由 show_snapped_window 的
+        // refresh_always_on_top 按 settings.is_pinned 重写,这里吃掉也白吃
         let _ = window.hide();
-        let _ = window.set_always_on_top(false);
         let _ = window.set_ignore_cursor_events(false);
     }
     set_snap_edge(
@@ -653,11 +671,8 @@ pub fn needs_hidden_snap_refresh(window: &WebviewWindow) -> Result<bool, String>
     }
 
     let settings = crate::get_settings();
-    // 真隐藏无触发条,OS 坐标与 state 屏外坐标本就不对齐,无需按位置刷
-    if !settings.edge_hover_popup_enabled {
-        return Ok(false);
-    }
-
+    // 即便 hover 关,显示器变更时也要让 snap_monitor_id 与 state 重同步,
+    // 避免拔屏后 reopen hover 时触发条漂到虚拟坐标
     let size = window.outer_size().map_err(|e| e.to_string())?;
     let (x, y, _, _) = crate::utils::positioning::get_window_bounds(window)?;
     let ratio = state
@@ -878,29 +893,17 @@ pub fn restore_edge_snap_on_startup(window: &WebviewWindow) -> Result<(), String
         Some(snapped_ratio),
     );
     set_hidden(true);
-    
-    window.set_position(tauri::PhysicalPosition::new(resolved.x, resolved.y))
-        .map_err(|e| e.to_string())?;
     save_snap_layout(resolved.edge, snapped_ratio, Some(resolved.monitor_id));
-
-    if settings.edge_hover_popup_enabled {
-        // 悬浮开启:show/置顶后再写穿透,避免 show 清掉 WS_EX_TRANSPARENT
-        let _ = window.show();
-        let _ = window.set_always_on_top(true);
-        let _ = window.set_ignore_cursor_events(true);
-    } else {
-        // 悬浮关闭:真正隐藏,并清掉置顶/穿透残留
-        let _ = window.hide();
-        let _ = window.set_always_on_top(false);
-        let _ = window.set_ignore_cursor_events(false);
-    }
-    
     super::state::set_window_state(super::state::WindowState::Hidden);
-    
+
+    // 形态决策(穿透/置顶/显隐)交给 refresh,与其他隐藏路径保持一致
+    refresh_hidden_snapped_window(window)?;
+
+    crate::services::memory::schedule_cleanup_after_main_window_hide();
     crate::input_monitor::disable_mouse_monitoring();
     crate::input_monitor::disable_navigation_keys();
-    
+
     super::edge_monitor::start_edge_monitoring();
-    
+
     Ok(())
 }

--- a/src-tauri/src/windows/main_window/snap.rs
+++ b/src-tauri/src/windows/main_window/snap.rs
@@ -1,5 +1,5 @@
 use tauri::{WebviewWindow, Manager, Emitter};
-use super::state::{SnapEdge, set_snap_edge, set_hidden, set_hidden_and_window_state, clear_snap, is_snapped};
+use super::state::{SnapEdge, set_snap_edge, set_hidden_and_window_state, clear_snap, is_snapped};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
@@ -10,7 +10,8 @@ static ANIMATION_VERSION: AtomicU64 = AtomicU64::new(0);
 
 // bump 动画版本号:让正在等待的 post-animation 任务醒来后自行退出,
 // 避免用过期设置改写形态(发现 toggle 反转、半屏滑入点穿等)
-fn cancel_pending_animation() {
+// pub(crate):tdd_tests 需要直接验证版本语义
+pub(crate) fn cancel_pending_animation() {
     ANIMATION_VERSION.fetch_add(1, Ordering::SeqCst);
 }
 
@@ -581,7 +582,8 @@ pub fn hide_snapped_window(window: &WebviewWindow) -> Result<(), String> {
 
     // 形态决策(穿透/置顶/显隐)全部交给 refresh_hidden_snapped_window 唯一决策点
     // 动画分支:先滑到屏外坐标,延迟 200ms 再 refresh,避免半屏状态被穿透导致触发条闪一下
-    if settings.edge_hover_popup_enabled && settings.clipboard_animation_enabled {
+    // 动画条件仅由 clipboard_animation_enabled 决定,不因 hover 关闭而跳过滑出动画
+    if settings.clipboard_animation_enabled {
         animate_window_position(window, x, y, resolved.x, resolved.y, 200)?;
         schedule_post_animation_refresh(window.clone(), window.app_handle().clone(), 200)?;
     } else {
@@ -639,8 +641,11 @@ pub fn refresh_hidden_snapped_window(window: &WebviewWindow) -> Result<(), Strin
         .map_err(|e| e.to_string())?;
 
     if settings.edge_hover_popup_enabled {
-        // 悬浮开启:触发条停留屏外但需保留可弹出,show 后立刻穿透,避免拦截边缘点击
-        let _ = window.show();
+        // 悬浮开启:触发条停留屏外但需保留可弹出,show 后立刻穿透,避免拦截边缘点击。
+        // 仅当窗口不可见时才 show,避免重复 show 激活/抢焦点打断用户操作
+        if !window.is_visible().unwrap_or(false) {
+            let _ = window.show();
+        }
         let _ = window.set_always_on_top(true);
         let _ = window.set_ignore_cursor_events(true);
     } else {
@@ -656,7 +661,9 @@ pub fn refresh_hidden_snapped_window(window: &WebviewWindow) -> Result<(), Strin
         Some(resolved.monitor_id.clone()),
         Some(ratio),
     );
-    set_hidden(true);
+    // 原子写 is_hidden + WindowState,避免与并发 toggle 交错时出现
+    // is_hidden=true 但 state=Visible 的撕裂态(会误判 should_show)
+    set_hidden_and_window_state(true, super::state::WindowState::Hidden);
     save_snap_layout(resolved.edge, ratio, Some(resolved.monitor_id));
 
     Ok(())
@@ -709,11 +716,17 @@ pub fn show_snapped_window(window: &WebviewWindow) -> Result<(), String> {
     crate::windows::preview_window::resume_preview_after_main_window_show();
 
     let state = super::state::get_window_state();
-    
+
     if !state.is_snapped || !state.is_hidden {
         return Ok(());
     }
-    
+
+    // 取消任何在飞的 hide 动画/post-refresh 任务:
+    // hide 动画先记账 is_hidden=true 再异步滑出,若用户立刻 toggle,
+    // 在飞 hide 帧/延迟 refresh 会继续写屏外坐标并覆盖本次 show 的形态,
+    // 导致窗口停在屏外且点穿。bump 版本让 hide 线程下一帧自杀。
+    cancel_pending_animation();
+
     let size = window.outer_size().map_err(|e| e.to_string())?;
     let (x, y, _, _) = crate::utils::positioning::get_window_bounds(window)?;
     let settings = crate::get_settings();
@@ -775,13 +788,15 @@ pub fn show_snapped_window(window: &WebviewWindow) -> Result<(), String> {
 }
 
 // 动画开始:独占一次 bump,取走当前版本。同一批动画后续的 post-refresh 不得再 bump。
-fn begin_animation() -> u64 {
+// pub(crate):tdd_tests 需要直接验证版本语义
+pub(crate) fn begin_animation() -> u64 {
     ANIMATION_VERSION.fetch_add(1, Ordering::SeqCst) + 1
 }
 
 // post-animation 刷新共享在飞动画的版本,不 bump。
 // 只有 cancel_pending_animation(同步形态决策)才会 bump,让动画与 post-refresh 一起失效。
-fn share_animation_version() -> u64 {
+// pub(crate):tdd_tests 需要直接验证版本语义
+pub(crate) fn share_animation_version() -> u64 {
     ANIMATION_VERSION.load(Ordering::SeqCst)
 }
 

--- a/src-tauri/src/windows/main_window/snap.rs
+++ b/src-tauri/src/windows/main_window/snap.rs
@@ -620,13 +620,20 @@ pub fn refresh_hidden_snapped_window(window: &WebviewWindow) -> Result<(), Strin
         settings.edge_hide_offset,
     )?;
 
+    // 形态唯一决策点:穿透/置顶/显隐都按开关在此处统一刷新,
+    // 所有调用方(开关切换、显示器变更、恢复默认大小)行为一致
     if settings.edge_hover_popup_enabled {
+        // 悬浮开启:露出透明触发条,保持置顶并点击穿透,避免拦截边缘点击
+        let _ = window.set_ignore_cursor_events(true);
+        let _ = window.set_always_on_top(true);
         window
             .set_position(tauri::PhysicalPosition::new(resolved.x, resolved.y))
             .map_err(|e| e.to_string())?;
     } else {
-        // 悬浮弹出关闭时窗口已真正隐藏,只更新状态即可
+        // 悬浮关闭:窗口已真正隐藏,取消置顶并恢复非穿透,保证形态状态一致
         let _ = window.hide();
+        let _ = window.set_always_on_top(false);
+        let _ = window.set_ignore_cursor_events(false);
     }
     set_snap_edge(
         resolved.edge,

--- a/src-tauri/src/windows/main_window/snap.rs
+++ b/src-tauri/src/windows/main_window/snap.rs
@@ -494,13 +494,13 @@ pub fn snap_to_edge(window: &WebviewWindow, edge: SnapEdge) -> Result<(), String
 
 pub fn hide_snapped_window(window: &WebviewWindow) -> Result<(), String> {
     use tauri::Manager;
-    
+
     let state = super::state::get_window_state();
-    
+
     if !state.is_snapped || state.is_hidden {
         return Ok(());
     }
-    
+
     if crate::is_context_menu_visible() {
         return Ok(());
     }
@@ -512,9 +512,10 @@ pub fn hide_snapped_window(window: &WebviewWindow) -> Result<(), String> {
     let _ = crate::windows::preview_window::close_preview_window(window.app_handle().clone());
     let _ = window.emit("edge-snap-hide", ());
 
+    let settings = crate::get_settings();
+
     let size = window.outer_size().map_err(|e| e.to_string())?;
     let (x, y, _, _) = crate::utils::positioning::get_window_bounds(window)?;
-    let settings = crate::get_settings();
     let ratio = compute_snap_ratio(
         window.app_handle(),
         state.snap_edge,
@@ -536,7 +537,26 @@ pub fn hide_snapped_window(window: &WebviewWindow) -> Result<(), String> {
         size.height as i32,
         settings.edge_hide_offset,
     )?;
-    
+
+    // 关闭"鼠标移到边缘弹出"时,直接真正隐藏窗口,
+    // 不留任何透明条,彻底避免残留透明框拦截点击
+    if !settings.edge_hover_popup_enabled {
+        let _ = window.hide();
+        set_snap_edge(
+            state.snap_edge,
+            Some((x, y)),
+            state.snap_monitor_id.clone(),
+            state.snap_ratio,
+        );
+        set_hidden(true);
+        save_snap_layout(state.snap_edge, state.snap_ratio.unwrap_or(0.5), state.snap_monitor_id.clone());
+        super::state::set_window_state(super::state::WindowState::Hidden);
+        crate::services::memory::schedule_cleanup_after_main_window_hide();
+        crate::input_monitor::disable_mouse_monitoring();
+        crate::input_monitor::disable_navigation_keys();
+        return Ok(());
+    }
+
     // 根据动画配置决定是否使用过渡
     if settings.clipboard_animation_enabled {
         animate_window_position(window, x, y, resolved.x, resolved.y, 200)?;
@@ -544,6 +564,8 @@ pub fn hide_snapped_window(window: &WebviewWindow) -> Result<(), String> {
         window.set_position(tauri::PhysicalPosition::new(resolved.x, resolved.y))
             .map_err(|e| e.to_string())?;
     }
+    // 隐藏状态让透明区域点击穿透,避免残留透明框拦截边缘点击
+    let _ = window.set_ignore_cursor_events(true);
     set_snap_edge(
         resolved.edge,
         Some((resolved.x, resolved.y)),
@@ -552,13 +574,13 @@ pub fn hide_snapped_window(window: &WebviewWindow) -> Result<(), String> {
     );
     set_hidden(true);
     save_snap_layout(resolved.edge, ratio, Some(resolved.monitor_id));
-    
+
     super::state::set_window_state(super::state::WindowState::Hidden);
     crate::services::memory::schedule_cleanup_after_main_window_hide();
-    
+
     crate::input_monitor::disable_mouse_monitoring();
     crate::input_monitor::disable_navigation_keys();
-    
+
     Ok(())
 }
 
@@ -596,9 +618,14 @@ pub fn refresh_hidden_snapped_window(window: &WebviewWindow) -> Result<(), Strin
         settings.edge_hide_offset,
     )?;
 
-    window
-        .set_position(tauri::PhysicalPosition::new(resolved.x, resolved.y))
-        .map_err(|e| e.to_string())?;
+    if settings.edge_hover_popup_enabled {
+        window
+            .set_position(tauri::PhysicalPosition::new(resolved.x, resolved.y))
+            .map_err(|e| e.to_string())?;
+    } else {
+        // 悬浮弹出关闭时窗口已真正隐藏,只更新状态即可
+        let _ = window.hide();
+    }
     set_snap_edge(
         resolved.edge,
         Some((resolved.x, resolved.y)),
@@ -664,6 +691,15 @@ pub fn show_snapped_window(window: &WebviewWindow) -> Result<(), String> {
     let size = window.outer_size().map_err(|e| e.to_string())?;
     let (x, y, _, _) = crate::utils::positioning::get_window_bounds(window)?;
     let settings = crate::get_settings();
+
+    // 显示时恢复鼠标事件捕获,确保窗口可交互
+    let _ = window.set_ignore_cursor_events(false);
+
+    // 鼠标悬浮弹出开关关闭时,窗口用 hide() 真正隐藏,此处需先 show 再移动
+    if !settings.edge_hover_popup_enabled {
+        let _ = window.show();
+    }
+
     let ratio = state
         .snap_ratio
         .or(settings.edge_snap_ratio)
@@ -839,9 +875,16 @@ pub fn restore_edge_snap_on_startup(window: &WebviewWindow) -> Result<(), String
     window.set_position(tauri::PhysicalPosition::new(resolved.x, resolved.y))
         .map_err(|e| e.to_string())?;
     save_snap_layout(resolved.edge, snapped_ratio, Some(resolved.monitor_id));
-    
-    let _ = window.show();
-    let _ = window.set_always_on_top(true);
+
+    if settings.edge_hover_popup_enabled {
+        // 悬浮弹出开启:保持窗口可见(露出透明触发条),鼠标靠近即可弹出
+        let _ = window.show();
+        let _ = window.set_always_on_top(true);
+    } else {
+        // 悬浮弹出关闭:直接真正隐藏,不留透明条
+        let _ = window.hide();
+        let _ = window.set_always_on_top(false);
+    }
     
     super::state::set_window_state(super::state::WindowState::Hidden);
     

--- a/src-tauri/src/windows/main_window/state.rs
+++ b/src-tauri/src/windows/main_window/state.rs
@@ -138,6 +138,57 @@ mod tests {
             "并发读观察到撕裂中间态:is_hidden=true 但 state != Hidden"
         );
     }
+
+    // refresh 形态决策后,is_hidden 与 WindowState 必须原子一致
+    #[test]
+    fn refresh_accounting_keeps_is_hidden_and_state_atomic() {
+        set_snap_edge(SnapEdge::Right, Some((0, 0)), None, Some(0.5));
+        set_hidden_and_window_state(true, WindowState::Hidden);
+        let state = get_window_state();
+        assert!(state.is_hidden, "refresh 后必须 is_hidden=true");
+        assert_eq!(
+            state.state,
+            WindowState::Hidden,
+            "refresh 后 WindowState 必须为 Hidden"
+        );
+        assert!(
+            state.is_hidden && state.state == WindowState::Hidden,
+            "is_hidden 与 state 不得出现撕裂态"
+        );
+    }
+
+    // 任何路径若绕过原子入口单独写 is_hidden(不写 state),会立刻变红
+    #[test]
+    fn non_atomic_set_hidden_can_tear_with_visible_state() {
+        set_snap_edge(SnapEdge::Right, Some((0, 0)), None, Some(0.5));
+        set_hidden_and_window_state(true, WindowState::Hidden);
+        let state = get_window_state();
+        assert!(
+            state.is_hidden && state.state == WindowState::Hidden,
+            "原子写后 is_hidden 与 state 必须一致,不得撕裂"
+        );
+    }
+
+    // refresh 末尾必须 re-check 状态,尊重并发 show 的写入,不反手覆盖
+    #[test]
+    fn refresh_state_write_must_recheck_concurrent_change() {
+        set_snap_edge(SnapEdge::Right, Some((0, 0)), None, Some(0.5));
+        let entry_is_hidden = get_window_state().is_hidden;
+        // 并发 show 抢占写 false/Visible
+        set_hidden_and_window_state(false, WindowState::Visible);
+        // refresh 末尾 re-check:中途已变 false,必须不再写回 true
+        if entry_is_hidden == get_window_state().is_hidden {
+            set_hidden_and_window_state(true, WindowState::Hidden);
+        }
+        let state = get_window_state();
+        assert!(
+            !state.is_hidden && state.state == WindowState::Visible,
+            "refresh 末尾必须尊重并发 show 的写入,不得反手覆盖。\
+             现状 is_hidden={} state={:?}",
+            state.is_hidden,
+            state.state
+        );
+    }
 }
 
 pub fn mark_clipboard_refresh_pending() {

--- a/src-tauri/src/windows/main_window/state.rs
+++ b/src-tauri/src/windows/main_window/state.rs
@@ -97,13 +97,26 @@ mod tests {
     use super::*;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Mutex, MutexGuard};
     use std::thread;
+
+    // 串行化所有写 WINDOW_STATE 的测试。
+    // 否则并发跑时 hidden_accounting 的 10000 次紧贴写会覆盖其他测试的写入,
+    // 读线程观测到撕裂中间态或读到错的 is_hidden。
+    // 并发读线程不持锁(只观测单次原子写后的快照),但本静态保证同一时刻
+    // 只有一个测试的写线程在跑,读者看到的"写"必属当前测试。
+    static SERIAL: Mutex<()> = Mutex::new(());
+
+    fn lock_serial() -> MutexGuard<'static, ()> {
+        SERIAL.lock().unwrap_or_else(|e| e.into_inner())
+    }
 
     // 回归:hide_snapped_window 的隐藏记账必须原子。
     // 并发读线程在写入期间不得观察到 is_hidden=true 但 state=Visible 的撕裂态,
     // 否则 toggle(热键/原始输入线程)会误判 should_show,让 hide 静默失败。
     #[test]
     fn hidden_accounting_is_atomic_under_concurrent_reads() {
+        let _g = lock_serial();
         // 先置入与 hide 前的状态:is_snapped + is_hidden=false + state=Visible
         set_snap_edge(SnapEdge::Right, Some((0, 0)), None, Some(0.5));
         set_hidden_and_window_state(false, WindowState::Visible);
@@ -142,6 +155,7 @@ mod tests {
     // refresh 形态决策后,is_hidden 与 WindowState 必须原子一致
     #[test]
     fn refresh_accounting_keeps_is_hidden_and_state_atomic() {
+        let _g = lock_serial();
         set_snap_edge(SnapEdge::Right, Some((0, 0)), None, Some(0.5));
         set_hidden_and_window_state(true, WindowState::Hidden);
         let state = get_window_state();
@@ -160,6 +174,7 @@ mod tests {
     // 任何路径若绕过原子入口单独写 is_hidden(不写 state),会立刻变红
     #[test]
     fn non_atomic_set_hidden_can_tear_with_visible_state() {
+        let _g = lock_serial();
         set_snap_edge(SnapEdge::Right, Some((0, 0)), None, Some(0.5));
         set_hidden_and_window_state(true, WindowState::Hidden);
         let state = get_window_state();
@@ -172,8 +187,13 @@ mod tests {
     // refresh 末尾必须 re-check 状态,尊重并发 show 的写入,不反手覆盖
     #[test]
     fn refresh_state_write_must_recheck_concurrent_change() {
+        let _g = lock_serial();
         set_snap_edge(SnapEdge::Right, Some((0, 0)), None, Some(0.5));
+        // 显式设置入口状态:refresh 入口必须看到 is_hidden=true,
+        // 串行化后 state 持久,不能依赖上一个 test 残留
+        set_hidden_and_window_state(true, WindowState::Hidden);
         let entry_is_hidden = get_window_state().is_hidden;
+        assert!(entry_is_hidden, "测试前提:refresh 入口必须 is_hidden=true");
         // 并发 show 抢占写 false/Visible
         set_hidden_and_window_state(false, WindowState::Visible);
         // refresh 末尾 re-check:中途已变 false,必须不再写回 true

--- a/src-tauri/src/windows/main_window/state.rs
+++ b/src-tauri/src/windows/main_window/state.rs
@@ -181,6 +181,13 @@ mod tests {
     // §5.4 护栏:refresh 的隐藏记账必须走原子入口 set_hidden_and_window_state,
     // 禁止裸写 set_hidden —— 两次独立 RwLock 写会让并发 toggle
     // 观测到 is_hidden=true 但 state=Visible 的撕裂态,误判 should_show。
+    //
+    // 负向断言 !body.contains("set_hidden(") 定位:
+    // 当下源码 snap.rs 函数体不含任何 set_hidden( 模式(全仓 fn set_hidden
+    // 零命中,该函数自 5a34ae1a 引入原子入口后已删),所以此断言当下始终通过;
+    // 它对"未来引入同名字面"防御——任何人加同名新函数会立刻让它失败。
+    // 属"未来防御"而非"当下行为护栏";d2150411 替换旧测试时未单独反证
+    // 见红,§7.13 主代理用 sed 临时注入已实测 FAILED,可证伪性成立。
     #[test]
     fn refresh_writes_hidden_accounting_through_atomic_entry() {
         let body = refresh_hidden_snapped_window_body();

--- a/src-tauri/src/windows/main_window/state.rs
+++ b/src-tauri/src/windows/main_window/state.rs
@@ -86,13 +86,6 @@ pub fn set_snap_edge(
     state.snap_ratio = ratio;
 }
 
-pub fn set_hidden(is_hidden: bool) {
-    WINDOW_STATE.write().is_hidden = is_hidden;
-}
-
-// 原子地同时写入隐藏标记与窗口状态,避免 hide_snapped_window 记账时
-// 被并发读侧(热键/原始输入线程的 toggle)观察到撕裂中间态
-// (is_hidden=true 但 state=Visible 会让 toggle 误判 should_show,导致 hide 静默失败)
 pub fn set_hidden_and_window_state(is_hidden: bool, window_state: WindowState) {
     let mut state = WINDOW_STATE.write();
     state.is_hidden = is_hidden;
@@ -113,8 +106,7 @@ mod tests {
     fn hidden_accounting_is_atomic_under_concurrent_reads() {
         // 先置入与 hide 前的状态:is_snapped + is_hidden=false + state=Visible
         set_snap_edge(SnapEdge::Right, Some((0, 0)), None, Some(0.5));
-        set_hidden(false);
-        set_window_state(WindowState::Visible);
+        set_hidden_and_window_state(false, WindowState::Visible);
 
         let stop = Arc::new(AtomicBool::new(false));
         let stop_read = stop.clone();

--- a/src-tauri/src/windows/main_window/state.rs
+++ b/src-tauri/src/windows/main_window/state.rs
@@ -90,6 +90,64 @@ pub fn set_hidden(is_hidden: bool) {
     WINDOW_STATE.write().is_hidden = is_hidden;
 }
 
+// 原子地同时写入隐藏标记与窗口状态,避免 hide_snapped_window 记账时
+// 被并发读侧(热键/原始输入线程的 toggle)观察到撕裂中间态
+// (is_hidden=true 但 state=Visible 会让 toggle 误判 should_show,导致 hide 静默失败)
+pub fn set_hidden_and_window_state(is_hidden: bool, window_state: WindowState) {
+    let mut state = WINDOW_STATE.write();
+    state.is_hidden = is_hidden;
+    state.state = window_state;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::thread;
+
+    // 回归:hide_snapped_window 的隐藏记账必须原子。
+    // 并发读线程在写入期间不得观察到 is_hidden=true 但 state=Visible 的撕裂态,
+    // 否则 toggle(热键/原始输入线程)会误判 should_show,让 hide 静默失败。
+    #[test]
+    fn hidden_accounting_is_atomic_under_concurrent_reads() {
+        // 先置入与 hide 前的状态:is_snapped + is_hidden=false + state=Visible
+        set_snap_edge(SnapEdge::Right, Some((0, 0)), None, Some(0.5));
+        set_hidden(false);
+        set_window_state(WindowState::Visible);
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_read = stop.clone();
+        let observed_tear = Arc::new(AtomicBool::new(false));
+        let tear_read = observed_tear.clone();
+
+        // 读线程:持续快照,检测撕裂态
+        let reader = thread::spawn(move || {
+            while !stop_read.load(Ordering::Relaxed) {
+                let state = get_window_state();
+                if state.is_snapped {
+                    if state.is_hidden && state.state != WindowState::Hidden {
+                        tear_read.store(true, Ordering::Relaxed);
+                    }
+                }
+            }
+        });
+
+        // 写线程:反复原子写入
+        for _ in 0..10000 {
+            set_hidden_and_window_state(true, WindowState::Hidden);
+            set_hidden_and_window_state(false, WindowState::Visible);
+        }
+
+        stop.store(true, Ordering::Relaxed);
+        reader.join().unwrap();
+        assert!(
+            !observed_tear.load(Ordering::Relaxed),
+            "并发读观察到撕裂中间态:is_hidden=true 但 state != Hidden"
+        );
+    }
+}
+
 pub fn mark_clipboard_refresh_pending() {
     WINDOW_STATE.write().clipboard_refresh_pending = true;
 }

--- a/src-tauri/src/windows/main_window/state.rs
+++ b/src-tauri/src/windows/main_window/state.rs
@@ -171,16 +171,30 @@ mod tests {
         );
     }
 
-    // 任何路径若绕过原子入口单独写 is_hidden(不写 state),会立刻变红
+    // 防回归:任何路径若绕过原子入口单独写 is_hidden(不写 state),会立刻变红。
+    // 本测试模拟"绕过"——在测试模块内直接 WINDOW_STATE.write().is_hidden = true
+    // 不写 state,断言读者能观测到撕裂中间态,迫使未来加 set_hidden 的人
+    // 必须改成原子入口或额外保证不撕裂。
     #[test]
-    fn non_atomic_set_hidden_can_tear_with_visible_state() {
+    fn bypass_atomic_entry_must_tear_with_visible_state() {
         let _g = lock_serial();
         set_snap_edge(SnapEdge::Right, Some((0, 0)), None, Some(0.5));
-        set_hidden_and_window_state(true, WindowState::Hidden);
-        let state = get_window_state();
+        // 入口:不撕裂的可见态
+        set_hidden_and_window_state(false, WindowState::Visible);
+        let pre = get_window_state();
+        assert!(!pre.is_hidden, "测试前提:入口必须 is_hidden=false");
+
+        // 绕过原子入口:只写 is_hidden,不写 state
+        WINDOW_STATE.write().is_hidden = true;
+
+        // 验证:中间态可观测(is_hidden=true 但 state=Visible),即"绕过会撕裂"
+        let torn = get_window_state();
         assert!(
-            state.is_hidden && state.state == WindowState::Hidden,
-            "原子写后 is_hidden 与 state 必须一致,不得撕裂"
+            torn.is_hidden && torn.state == WindowState::Visible,
+            "绕过原子入口应产生撕裂中间态:is_hidden=true 但 state=Visible \
+             (现状 is_hidden={} state={:?})",
+            torn.is_hidden,
+            torn.state
         );
     }
 

--- a/src-tauri/src/windows/main_window/state.rs
+++ b/src-tauri/src/windows/main_window/state.rs
@@ -152,29 +152,52 @@ mod tests {
         );
     }
 
-    // refresh 形态决策后,is_hidden 与 WindowState 必须原子一致
+    // 读取 snap.rs 中 refresh_hidden_snapped_window 的函数体源码。
+    // 该函数需要 WebviewWindow,无法在 lib test 中构造调用,
+    // 故按 §10.3 用源码字面存在性护栏锁死其不变量。
+    // 运行时读源(include_str! 自指会编译期递归,不可用)。
+    fn refresh_hidden_snapped_window_body() -> String {
+        let source = std::fs::read_to_string(format!(
+            "{}/src/windows/main_window/snap.rs",
+            env!("CARGO_MANIFEST_DIR")
+        ))
+        .expect("找不到 src/windows/main_window/snap.rs 源文件");
+        let start = source
+            .find("pub fn refresh_hidden_snapped_window")
+            .expect("找不到 refresh_hidden_snapped_window 定义");
+        let after = &source[start..];
+        let end_rel = after[1..]
+            .find("\npub fn ")
+            .map(|rel| rel + 1)
+            .unwrap_or(after.len());
+        // 剥掉行注释再匹配:否则注释里出现被测字面会误命中(§10.4 记录的陷阱)
+        after[..end_rel]
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    // §5.4 护栏:refresh 的隐藏记账必须走原子入口 set_hidden_and_window_state,
+    // 禁止裸写 set_hidden —— 两次独立 RwLock 写会让并发 toggle
+    // 观测到 is_hidden=true 但 state=Visible 的撕裂态,误判 should_show。
     #[test]
-    fn refresh_accounting_keeps_is_hidden_and_state_atomic() {
-        let _g = lock_serial();
-        set_snap_edge(SnapEdge::Right, Some((0, 0)), None, Some(0.5));
-        set_hidden_and_window_state(true, WindowState::Hidden);
-        let state = get_window_state();
-        assert!(state.is_hidden, "refresh 后必须 is_hidden=true");
-        assert_eq!(
-            state.state,
-            WindowState::Hidden,
-            "refresh 后 WindowState 必须为 Hidden"
+    fn refresh_writes_hidden_accounting_through_atomic_entry() {
+        let body = refresh_hidden_snapped_window_body();
+        assert!(
+            body.contains("set_hidden_and_window_state(true, super::state::WindowState::Hidden)"),
+            "refresh_hidden_snapped_window 必须用原子入口写隐藏记账"
         );
         assert!(
-            state.is_hidden && state.state == WindowState::Hidden,
-            "is_hidden 与 state 不得出现撕裂态"
+            !body.contains("set_hidden("),
+            "refresh_hidden_snapped_window 禁止裸写 set_hidden,必须走原子入口"
         );
     }
 
-    // 防回归:任何路径若绕过原子入口单独写 is_hidden(不写 state),会立刻变红。
-    // 本测试模拟"绕过"——在测试模块内直接 WINDOW_STATE.write().is_hidden = true
-    // 不写 state,断言读者能观测到撕裂中间态,迫使未来加 set_hidden 的人
-    // 必须改成原子入口或额外保证不撕裂。
+    // 文档化演示:说明"绕过原子入口会撕裂"这个前提本身成立。
+    // 注意本测试不拦截生产代码 —— 真正的防回归由
+    // refresh_writes_hidden_accounting_through_atomic_entry 的源码护栏负责。
+    // 此处只固化撕裂的可观测性,让 set_hidden_and_window_state 的存在理由自解释。
     #[test]
     fn bypass_atomic_entry_must_tear_with_visible_state() {
         let _g = lock_serial();
@@ -198,29 +221,28 @@ mod tests {
         );
     }
 
-    // refresh 末尾必须 re-check 状态,尊重并发 show 的写入,不反手覆盖
+    // §5.4 + §6 护栏:refresh 末尾写回 Hidden 之前必须 re-check 当前状态,
+    // 若中途被并发 show 抢先写 (false, Visible),尊重对方写入不反手覆盖,
+    // 否则 toggle 会反复走 hide 路径。
+    // 断言 re-check 的 if 字面存在,且下标严格早于原子写 —— 只 contains
+    // 无法区分"检查在写之前"还是"写完才检查"。
     #[test]
-    fn refresh_state_write_must_recheck_concurrent_change() {
-        let _g = lock_serial();
-        set_snap_edge(SnapEdge::Right, Some((0, 0)), None, Some(0.5));
-        // 显式设置入口状态:refresh 入口必须看到 is_hidden=true,
-        // 串行化后 state 持久,不能依赖上一个 test 残留
-        set_hidden_and_window_state(true, WindowState::Hidden);
-        let entry_is_hidden = get_window_state().is_hidden;
-        assert!(entry_is_hidden, "测试前提:refresh 入口必须 is_hidden=true");
-        // 并发 show 抢占写 false/Visible
-        set_hidden_and_window_state(false, WindowState::Visible);
-        // refresh 末尾 re-check:中途已变 false,必须不再写回 true
-        if entry_is_hidden == get_window_state().is_hidden {
-            set_hidden_and_window_state(true, WindowState::Hidden);
-        }
-        let state = get_window_state();
+    fn refresh_rechecks_state_before_writing_hidden_back() {
+        let body = refresh_hidden_snapped_window_body();
+        let recheck = body
+            .find("if super::state::get_window_state().is_hidden {")
+            .expect(
+                "refresh_hidden_snapped_window 必须在末尾写回前 re-check \
+                 get_window_state().is_hidden,尊重并发 show 的写入",
+            );
+        let write = body
+            .find("set_hidden_and_window_state(true, super::state::WindowState::Hidden)")
+            .expect("找不到 refresh 末尾的原子写");
         assert!(
-            !state.is_hidden && state.state == WindowState::Visible,
-            "refresh 末尾必须尊重并发 show 的写入,不得反手覆盖。\
-             现状 is_hidden={} state={:?}",
-            state.is_hidden,
-            state.state
+            recheck < write,
+            "re-check 必须早于原子写回,现状 recheck={} write={}",
+            recheck,
+            write
         );
     }
 }

--- a/src/shared/locales/en-US.json
+++ b/src/shared/locales/en-US.json
@@ -781,6 +781,8 @@
       "positionRight": "Right",
       "edgeHideEnabled": "Enable Edge Snap Hide",
       "edgeHideEnabledDesc": "Automatically hide window when snapped to screen edge",
+      "edgeHoverPopup": "Show on Mouse Hover at Edge",
+      "edgeHoverPopupDesc": "When disabled, hovering the mouse at the screen edge will not show the window; use shortcut key or tray icon instead",
       "edgeHideOffset": "Visible Pixels When Hidden",
       "edgeHideOffsetDesc": "Number of pixels protruding when the window is hidden at edge",
       "autoFocusSearch": "Auto Focus Search Box",

--- a/src/shared/locales/zh-CN.json
+++ b/src/shared/locales/zh-CN.json
@@ -781,6 +781,8 @@
       "positionRight": "右侧",
       "edgeHideEnabled": "启用贴边隐藏",
       "edgeHideEnabledDesc": "窗口在屏幕边缘时自动隐藏",
+      "edgeHoverPopup": "鼠标移到边缘自动弹出",
+      "edgeHoverPopupDesc": "关闭后鼠标移到屏幕边缘不会弹出窗口，需通过快捷键或托盘唤出",
       "edgeHideOffset": "贴边隐藏突出像素",
       "edgeHideOffsetDesc": "窗口贴边隐藏时突出显示的像素数",
       "autoFocusSearch": "自动聚焦搜索框",

--- a/src/shared/services/settingsService.js
+++ b/src/shared/services/settingsService.js
@@ -89,6 +89,7 @@ export const defaultSettings = {
   rememberWindowSize: true,
   titleBarPosition: 'top',
   edgeHideEnabled: true,
+  edgeHoverPopupEnabled: true,
   edgeSnapPosition: null,
   edgeHideOffset: 3,
   autoFocusSearch: false,

--- a/src/windows/settings/sections/ClipboardSection.jsx
+++ b/src/windows/settings/sections/ClipboardSection.jsx
@@ -115,7 +115,17 @@ function ClipboardSection({
         </SettingItem>
 
         <SettingItem label={t('settings.clipboard.edgeHideEnabled')} description={t('settings.clipboard.edgeHideEnabledDesc')}>
-          <Toggle checked={settings.edgeHideEnabled} onChange={checked => onSettingChange('edgeHideEnabled', checked)} />
+          <Toggle
+            checked={settings.edgeHideEnabled}
+            onChange={checked => {
+              // 后端守不变量:hover 蕴含 hide,关 hide 必须连带关 hover,
+              // 前端同步批量更新,避免 store 与后端归一化后的状态分叉
+              onSettingChange('edgeHideEnabled', checked)
+              if (!checked) {
+                onSettingChange('edgeHoverPopupEnabled', false)
+              }
+            }}
+          />
         </SettingItem>
 
         <SettingItem label={t('settings.clipboard.edgeHoverPopup')} description={t('settings.clipboard.edgeHoverPopupDesc')}>

--- a/src/windows/settings/sections/ClipboardSection.jsx
+++ b/src/windows/settings/sections/ClipboardSection.jsx
@@ -119,7 +119,11 @@ function ClipboardSection({
         </SettingItem>
 
         <SettingItem label={t('settings.clipboard.edgeHoverPopup')} description={t('settings.clipboard.edgeHoverPopupDesc')}>
-          <Toggle checked={settings.edgeHoverPopupEnabled !== false} onChange={checked => onSettingChange('edgeHoverPopupEnabled', checked)} />
+          <Toggle
+            checked={settings.edgeHoverPopupEnabled !== false}
+            onChange={checked => onSettingChange('edgeHoverPopupEnabled', checked)}
+            disabled={!settings.edgeHideEnabled}
+          />
         </SettingItem>
 
         <SettingItem label={t('settings.clipboard.edgeHideOffset')} description={t('settings.clipboard.edgeHideOffsetDesc')}>

--- a/src/windows/settings/sections/ClipboardSection.jsx
+++ b/src/windows/settings/sections/ClipboardSection.jsx
@@ -118,6 +118,10 @@ function ClipboardSection({
           <Toggle checked={settings.edgeHideEnabled} onChange={checked => onSettingChange('edgeHideEnabled', checked)} />
         </SettingItem>
 
+        <SettingItem label={t('settings.clipboard.edgeHoverPopup')} description={t('settings.clipboard.edgeHoverPopupDesc')}>
+          <Toggle checked={settings.edgeHoverPopupEnabled !== false} onChange={checked => onSettingChange('edgeHoverPopupEnabled', checked)} />
+        </SettingItem>
+
         <SettingItem label={t('settings.clipboard.edgeHideOffset')} description={t('settings.clipboard.edgeHideOffsetDesc')}>
           <Input type="number" value={settings.edgeHideOffset ?? 3} onChange={e => onSettingChange('edgeHideOffset', parseInt(e.target.value))} min={0} max={50} className="w-24" suffix={t('settings.common.pixels')} />
         </SettingItem>


### PR DESCRIPTION
fix(贴边隐藏): 透明残留框拦截点击并支持关闭悬浮弹出

Closes #441

问题
贴边隐藏后窗口 hide()，但 Windows 上 `WS_EX_TRANSPARENT` 机制仍把透明矩形算作窗口命中区，鼠标点击被吃掉。表现：触发条四角能识别，中间区域点击无响应。
复现：v0.4.0 / v0.4.1 均有报告，#441 有截图。
根因：贴边隐藏的 show/hide 路径从未设置穿透。

方案
新增 `edgeHoverPopupEnabled` 设置项（默认 true），把「留触发条悬浮弹出」做成可选项：
- 开关打开：贴边隐藏时滑出触发条，鼠标靠近弹出，触发条 `set_ignore_cursor_events(true)` 穿透。
- 开关关闭：贴边隐藏 = 真正 `hide()`，不留任何透明条，只能靠快捷键/托盘唤出。
显示、恢复、刷新路径必须同步 `set_ignore_cursor_events(false)` 关闭穿透。

行为契约
1. 开关语义
   - `edgeHoverPopupEnabled=true`  → 留触发条 + 悬浮弹出
   - `edgeHoverPopupEnabled=false` → 贴边时真 hide()，无触发条
   - 关 `edgeHideEnabled` 必须连带关 `edgeHoverPopupEnabled`（前端 onSettingChange 批量写；后端 `normalize_edge_hover_invariant` 兜底）

2. 形态决策唯一入口
   - 所有隐藏/显示路径（hide/show/restore/设置切换/启动恢复）只走 `refresh_hidden_snapped_window`
   - 内部顺序固定：`cancel → resolve → set_position → show/hide → topmost → ignore`
   - 禁止任何路径内联 `window.show()` / `set_always_on_top()` / `set_ignore_cursor_events()` / `window.hide()`

3. 穿透方向
   - `set_ignore_cursor_events(true)` = 穿透
   - 悬浮开启时触发条必须穿透（false 会拦截边缘点击）
   - 悬浮关闭时窗口真隐藏，无需穿透
   - 实现侧直接传 `enabled`，无 `!enabled` 反转

4. 隐藏记账原子化
   - 所有路径走 `set_hidden_and_window_state(is_hidden, window_state)` 原子写
   - 禁止裸 `set_hidden` —— 两次独立 RwLock 写会观测到 `is_hidden=true but state=Visible` 撕裂态

5. 动画令牌
   - `begin_animation` 独占初始 bump（拿当前版本号）
   - `cancel_pending_animation`（同步形态决策）可 bump（让在飞动画 + post-refresh 一起失效）
   - `share_animation_version` 共享在飞版本，load 不 bump

6. 设置不变量
   - 单箭头：`edge_hide_enabled=false` ⇒ `edge_hover_popup_enabled=false`
   - 反向不蕴含：开 hide 不自动开 hover，保留用户上次偏好
   - `AppSettings::normalize_edge_hover_invariant` 在所有写入入口（load / save / JSON 导入 / set_edge_hide_enabled / Default / update_with）统一调用

7. 形态刷新顺序
   - `update_settings` 必须在形态刷新之前落地新值
   - `save_settings` 与 `set_edge_hide_enabled` 两处已守

改动
- 13 文件 / +1015 / −79
- 关键文件：
  - `src-tauri/src/windows/main_window/snap.rs`（refresh 唯一决策点 + 动画 + 穿透）
  - `src-tauri/src/windows/main_window/state.rs`（原子写 + 源码字面护栏）
  - `src-tauri/src/commands/settings.rs`（save/set 顺序、归一化、护栏测试）
  - 前端设置项 + zh-CN / en-US locale

验证
- `cargo test --lib --no-default-features`：58 passed; 0 failed; 0 ignored
- 关键不变量用源码字面护栏（`fs::read_to_string` + helper 剥行注释）锁死：
  - `refresh_writes_hidden_accounting_through_atomic_entry`
  - `refresh_rechecks_state_before_writing_hidden_back`
  - `save_settings_handle_disable_edge_hide_runs_after_update_settings`
  - `set_edge_hide_enabled_handle_disable_edge_hide_runs_after_update_settings`
  - `normalize_edge_hover_invariant` 在 10 处写入入口统一调用，5 类路径全覆盖

兼容性
- 默认值 `edgeHoverPopupEnabled=true`，与 v0.4.1 行为接近，且修了透明拦截问题
- 老配置无此字段：`AppSettings::default()` 兜底为 true
- `edgeHideEnabled=false` 的老用户：前端批量更新连带关 hover，store 与后端不变量一致
