### PR TITLE
fix: 主窗口隐藏时注销导航全局快捷键

### DIFF
--- a/src-tauri/src/services/system/hotkey/navigation.rs
+++ b/src-tauri/src/services/system/hotkey/navigation.rs
@@ -268,6 +268,16 @@ fn should_suspend_navigation_hotkeys() -> bool {
     !super::global::is_hotkeys_enabled()
         || !crate::get_settings().hotkeys_enabled
         || crate::services::system::is_front_app_globally_disabled_from_settings()
+        // 主窗口隐藏时必须注销导航快捷键，避免 ESC/Tab/Enter/方向键等单键
+        // 被注册为全局热键后从其他应用中被“偷走”
+        || !is_main_window_visible()
+}
+
+fn is_main_window_visible() -> bool {
+    get_app()
+        .ok()
+        .map(|app| crate::windows::main_window::is_main_window_visible(&app))
+        .unwrap_or(false)
 }
 
 fn emit_navigation_action_if_ready(action: &str) -> bool {


### PR DESCRIPTION
## 问题

QuickClipboard v0.4.2 会把“窗口内导航快捷键”注册为**系统级全局热键**（`tauri-plugin-global-shortcut` / `RegisterHotKey`）：

- ESC（隐藏窗口）
- Tab（聚焦搜索）
- Enter（粘贴）
- ↑↓←→（导航）

当主窗口隐藏后，这些热键仍可能保持注册状态，导致 ESC / Tab / Enter / 方向键在其他应用中完全失效（`RegisterHotKey` 返回 `ERROR_HOTKEY_ALREADY_REGISTERED` 1409）。实测系统中被占用的按键清单与设置项一一对应。

## 原因

`src-tauri/src/services/system/hotkey/navigation.rs` 中 `should_suspend_navigation_hotkeys()` 只检查：

- 全局热键总开关
- `settings.hotkeys_enabled`
- 前台应用是否被过滤

没有检查主窗口是否可见。只要某条隐藏路径漏掉 `disable_navigation_keys()`，导航热键就会一直占用系统按键，且之后每次前台切换都会再次同步保持注册状态。

## 修复

在 `should_suspend_navigation_hotkeys()` 中增加主窗口可见性守卫：

- 主窗口不可见时，`sync_navigation_hotkeys_for_foreground()` 会在前台窗口切换时自动注销全部导航全局热键；
- 即使某条隐藏路径漏掉了显式注销，系统也会在下一个前台切换事件中自愈。

行为保持原设计：只有在剪贴板主窗口显示时，才允许通过全局热键进行无焦点导航；窗口隐藏后按键立即归还系统。

## 验证

- 本地环境无 Rust 工具链，未执行 `cargo build`；改动为纯逻辑守卫（新增一个辅助函数 + 一个条件判断）。
- 复现/验证建议：打开剪贴板窗口后隐藏，用 `RegisterHotKey` 探测 ESC 应恢复可注册；修复前会返回 1409。