### PR TITLE
refactor(前端): 清除 28 个零调用者的死代码 API 封装

### DIFF
--- a/src/shared/api/clipboard.js
+++ b/src/shared/api/clipboard.js
@@ -127,28 +127,6 @@ export async function addToFavorites(id) {
   }
 }
 
-
-// 检查文件是否存在
-export async function checkFileExists(path) {
-  try {
-    return await invoke('file_exists', { path })
-  } catch (error) {
-    console.warn(`检查文件是否存在失败: ${path}`, error)
-    return false
-  }
-}
-
-// 打开文本编辑器
-export async function openTextEditor() {
-  try {
-    await invoke('open_text_editor_window')
-    return true
-  } catch (error) {
-    console.error('打开文本编辑器失败:', error)
-    throw error
-  }
-}
-
 // 贴图片到屏幕
 export async function pinImageToScreen(filePath) {
   try {
@@ -159,18 +137,6 @@ export async function pinImageToScreen(filePath) {
     throw error
   }
 }
-
-// 保存图片到文件
-export async function saveImageToFile(content, filePath) {
-  try {
-    await invoke('save_image_to_file', { content, filePath })
-    return true
-  } catch (error) {
-    console.error('保存图片失败:', error)
-    throw error
-  }
-}
-
 
 // 获取单个剪贴板项
 export async function getClipboardItemById(id, maxLength = null) {
@@ -228,7 +194,6 @@ export async function addClipboardToFavorites(id, groupName) {
   })
   return favoriteItem
 }
-
 
 // 另存图片
 export async function saveImageFromPath(filePath) {

--- a/src/shared/api/dropProxy.js
+++ b/src/shared/api/dropProxy.js
@@ -27,10 +27,6 @@ export async function hideDropProxy() {
   return await invoke('drop_proxy_hide');
 }
 
-export async function disposeDropProxy() {
-  return await invoke('drop_proxy_dispose');
-}
-
 export async function routeDropProxyPathsAtCursor(paths, cursorPos) {
   return await invoke('drop_proxy_route_paths_at_cursor', { paths, cursorPos });
 }

--- a/src/shared/api/groups.js
+++ b/src/shared/api/groups.js
@@ -35,8 +35,3 @@ export async function moveFavoriteToGroup(id, groupName) {
   return await invoke('move_quick_text_to_group', { id, groupName })
 }
 
-// 从剪贴板添加到分组
-export async function addClipboardToGroup(index, groupName) {
-  return await invoke('add_clipboard_to_group', { index, groupName })
-}
-

--- a/src/shared/api/imageLibrary.js
+++ b/src/shared/api/imageLibrary.js
@@ -16,11 +16,6 @@ async function uint8ArrayToNumberArrayChunked(data, chunkSize = 256 * 1024) {
   return result
 }
 
-// 初始化图片库目录
-export async function initImageLibrary() {
-  return await invoke('il_init')
-}
-
 // 保存图片
 export async function saveImage(group, filename, data) {
   const payloadData = await uint8ArrayToNumberArrayChunked(data)
@@ -88,16 +83,6 @@ export async function deleteImageGroup(name, moveImagesToDefault = false) {
   return await invoke('il_delete_group', {
     payload: { name, move_images_to_default: moveImagesToDefault }
   })
-}
-
-// 获取图片目录路径
-export async function getImagesDir() {
-  return await invoke('il_get_images_dir')
-}
-
-// 获取 GIF 目录路径
-export async function getGifsDir() {
-  return await invoke('il_get_gifs_dir')
 }
 
 // 将本地路径转换为URL

--- a/src/shared/api/receiveBox.js
+++ b/src/shared/api/receiveBox.js
@@ -4,10 +4,6 @@ export async function openReceiveBox() {
   return await invoke('receive_box_open');
 }
 
-export async function focusReceiveBox() {
-  return await invoke('receive_box_focus');
-}
-
 export async function listReceiveBoxLanFiles() {
   return await invoke('receive_box_list_lan_files');
 }

--- a/src/shared/api/settings.js
+++ b/src/shared/api/settings.js
@@ -60,16 +60,6 @@ export async function getShortcutStatuses() {
   return await invoke('get_shortcut_statuses')
 }
 
-// 获取单个快捷键状态
-export async function getShortcutStatus(id) {
-  return await invoke('get_shortcut_status', { id })
-}
-
-// 重新加载快捷键
-export async function reloadHotkeys() {
-  return await invoke('reload_hotkeys')
-}
-
 // 保存窗口位置
 export async function saveWindowPosition(x, y) {
   return await invoke('save_window_position', { x, y })

--- a/src/shared/api/sound.js
+++ b/src/shared/api/sound.js
@@ -1,15 +1,5 @@
 import { invoke } from '@tauri-apps/api/core'
 
-// 播放指定音频文件
-export async function playSound(path, volume = 0.5) {
-  return await invoke('play_sound', { path, volume })
-}
-
-// 播放蜂鸣音
-export async function playBeep(frequency = 800, durationMs = 100, volume = 0.5) {
-  return await invoke('play_beep', { frequency, durationMs, volume })
-}
-
 // 播放复制音效
 export async function playCopySound() {
   return await invoke('play_copy_sound')

--- a/src/shared/api/syncTransfer.js
+++ b/src/shared/api/syncTransfer.js
@@ -8,14 +8,6 @@ export async function getSyncTransferLanStatus() {
   return await invoke('sync_transfer_lan_get_status');
 }
 
-export async function startSyncTransferLanHttpServer() {
-  return await invoke('sync_transfer_lan_start_http_server');
-}
-
-export async function stopSyncTransferLanHttpServer() {
-  return await invoke('sync_transfer_lan_stop_http_server');
-}
-
 export async function refreshSyncTransferLanPairingCode() {
   return await invoke('sync_transfer_lan_refresh_pairing_code');
 }
@@ -63,22 +55,9 @@ export async function updateSyncTransferLanAutoSyncSettings(settings) {
   });
 }
 
-export async function pullSyncTransferLanPeer(deviceId) {
-  return await invoke('sync_transfer_lan_pull_from_peer', {
-    deviceId,
-  });
-}
-
 export async function pushSyncTransferLanPeer(deviceId) {
   return await invoke('sync_transfer_lan_push_to_peer', {
     deviceId,
   });
 }
 
-export async function sendSyncTransferLanFileToPeer(deviceId, filePath, transferId = null) {
-  return await invoke('sync_transfer_lan_send_file_to_peer', {
-    deviceId,
-    filePath,
-    transferId,
-  });
-}

--- a/src/shared/api/system.js
+++ b/src/shared/api/system.js
@@ -5,25 +5,9 @@ export async function getAppVersion() {
   return await invoke('get_app_version')
 }
 
-
 // 检查是否为便携模式
 export async function isPortableMode() {
   return await invoke('is_portable_mode')
-}
-
-// 检查 AI 翻译配置
-export async function checkAiTranslationConfig() {
-  return await invoke('check_ai_translation_config')
-}
-
-// 启用 AI 翻译取消快捷键
-export async function enableAiTranslationCancelShortcut() {
-  return await invoke('enable_ai_translation_cancel_shortcut')
-}
-
-// 禁用 AI 翻译取消快捷键
-export async function disableAiTranslationCancelShortcut() {
-  return await invoke('disable_ai_translation_cancel_shortcut')
 }
 
 // 复制文本
@@ -34,21 +18,6 @@ export async function copyTextToClipboard(text) {
 // OCR识别图片文件
 export async function recognizeImageOcr(filePath, language = null) {
   return await invoke('recognize_file_ocr', { filePath, language })
-}
-
-// 检查系统 Win+V 快捷键是否已禁用
-export async function checkWinVHotkeyDisabled() {
-  return await invoke('check_win_v_hotkey_disabled')
-}
-
-// 禁用系统 Win+V 快捷键并重启资源管理器
-export async function disableWinVHotkeyAndRestart() {
-  return await invoke('disable_win_v_hotkey_and_restart')
-}
-
-// 启用系统 Win+V 快捷键并重启资源管理器
-export async function enableWinVHotkeyAndRestart() {
-  return await invoke('enable_win_v_hotkey_and_restart')
 }
 
 export async function promptDisableWinVHotkeyIfNeeded() {

--- a/src/shared/api/transferShelf.js
+++ b/src/shared/api/transferShelf.js
@@ -8,10 +8,6 @@ export async function listTransferShelves() {
   return await invoke('transfer_shelf_list');
 }
 
-export async function focusTransferShelf(id) {
-  return await invoke('transfer_shelf_focus', { id });
-}
-
 export async function renameTransferShelf(id, name) {
   return await invoke('transfer_shelf_rename', { id, name });
 }
@@ -52,6 +48,3 @@ export async function saveTransferShelfGeometry(id) {
   return await invoke('transfer_shelf_save_geometry', { id });
 }
 
-export async function applyTransferShelfGeometry(id) {
-  return await invoke('transfer_shelf_apply_geometry', { id });
-}

--- a/src/shared/api/webdavSync.js
+++ b/src/shared/api/webdavSync.js
@@ -16,10 +16,6 @@ export async function downloadAllWebdav() {
   return await invoke('webdav_download_all');
 }
 
-export async function getWebdavStatus() {
-  return await invoke('webdav_get_status');
-}
-
 export async function getWebdavLastReport() {
   return await invoke('webdav_get_last_report');
 }

--- a/src/shared/api/window.js
+++ b/src/shared/api/window.js
@@ -5,11 +5,6 @@ export async function setWindowPinned(pinned) {
   return await invoke('set_window_pinned', { pinned })
 }
 
-// 切换窗口可见性
-export async function toggleWindowVisibility() {
-  return await invoke('toggle_window_visibility')
-}
-
 // 隐藏主窗口
 export async function hideMainWindow() {
   return await invoke('hide_main_window')
@@ -33,11 +28,6 @@ export async function restoreLastFocus() {
 // 开始自定义拖拽
 export async function startCustomDrag(mouseScreenX, mouseScreenY) {
   return await invoke('start_custom_drag', { mouseScreenX, mouseScreenY })
-}
-
-// 停止自定义拖拽
-export async function stopCustomDrag() {
-  return await invoke('stop_custom_drag')
 }
 
 // 打开设置窗口


### PR DESCRIPTION
## 这个 PR 做什么

清除 28 个零调用者的前端死代码 API 封装。对抗审查（adversarial-review，#475 的审查）F4 确认：这些函数全仓库零调用者，属前端死代码。

## 验证过程

1. grep 调用者扫描：28 个导出函数在 src 全范围零调用
2. 全仓兜底 grep（含 src 之外）：零外部引用

## 改动

12 个文件（clipboard/groups/dropProxy/imageLibrary/receiveBox/settings/sound/syncTransfer/system/transferShelf/webdavSync/window），156 行纯删除，0 行新增。npm run build 通过。

## 后端对应关系（供后续清理参考）

- checkFileExists / saveImageToFile / addClipboardToGroup 三个封装后端本无命令
- 其余 25 个命令后端仍注册：open_text_editor_window 有存活的 textEditor.js 调用者（被删的 openTextEditor 封装调用它时不传参数，运行时会缺参报错，确证其为死码）；另 24 个命令已成为孤儿，留待后续单独的后端清理 PR

## 对抗审查（针对本 PR 的工作流）

9 条 findings 全部存活（3/3 反驳失败）、0 丢弃：无误删、边界干净、import 完整、与 #475 交互正确（pinImageToScreen 保留——main 上有 contextMenu.js 右键菜单调用者，属 #475 清理范围）、构建通过。推荐合并。

注：与 #475 独立，此 PR 基于 main 直接拉出，不含贴图清理内容。#475 合并时 clipboard.js 相邻 hunk 可能需手动解冲突，终态一致。
