### PR TITLE
fix: upgrade openssl to 0.10.78 (CVE-2026-41676)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4561,9 +4561,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
@@ -4593,9 +4593,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Summary
Upgrade openssl from 0.10.75 to 0.10.78 to fix CVE-2026-41676.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-41676 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-41676` |
| **File** | `src-tauri/Cargo.lock` (dependency: `openssl`) |
| **Assessment** | Likely exploitable |

**Description**: rust-openssl provides OpenSSL bindings for the Rust programming langua ...

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-41676` flagged this pattern.

## Changes
- `src-tauri/Cargo.lock`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
