### PR TITLE
fix: 粘贴注入跨前台切换导致修饰键卡住，回车/方向键全局失效 (#496)

### DIFF
--- a/src-tauri/plugins/low-memory-fltk/src/lib.rs
+++ b/src-tauri/plugins/low-memory-fltk/src/lib.rs
@@ -98,6 +98,9 @@ static UI_CALLBACK: Lazy<Mutex<Option<UiCallback>>> = Lazy::new(|| Mutex::new(No
 static UI_STARTED: AtomicBool = AtomicBool::new(false);
 static UI_VISIBLE: AtomicBool = AtomicBool::new(false);
 static PANEL_BOUNDS: Lazy<Mutex<Option<(i32, i32, i32, i32)>>> = Lazy::new(|| Mutex::new(None));
+// 面板窗口的原生句柄：FLTK 每次 Show 重建 OS 窗口，句柄随 Show 刷新
+// （FLTK 线程写入）、随隐藏落地清空（隐藏会销毁 OS 窗口，句柄随之失效）
+static PANEL_HWND: Lazy<Mutex<Option<isize>>> = Lazy::new(|| Mutex::new(None));
 
 const DEFAULT_WIDTH: i32 = 420;
 const ROW_HEIGHT: i32 = 18;
@@ -189,6 +192,22 @@ fn lock_or_recover<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
 
 fn ui_callback() -> Option<UiCallback> {
     lock_or_recover(&UI_CALLBACK).clone()
+}
+
+// 发出一次 UiEvent::Hidden。win.hide() 内部会同步重入窗口事件闭包
+// （FL_HIDE 先于 DestroyWindow 派发），重入与外层分支各到达一次；以
+// UI_VISIBLE 的 true→false 交换去重，保证每次可见→隐藏转换只回调一次
+// ——fltk 升级改变 FL_HIDE 重入时机时，无论哪一侧落地，仍恰好一次
+fn emit_hidden_once() {
+    if UI_VISIBLE.swap(false, Ordering::SeqCst) {
+        if let Some(callback) = ui_callback() {
+            callback(UiEvent::Hidden);
+        }
+        // 隐藏落地后 OS 窗口即将销毁：回调（FL_HIDE 先于 DestroyWindow
+        // 派发、此时句柄仍有效）读取之后清空，避免残留已销毁句柄被
+        // 后续埋点误用
+        *lock_or_recover(&PANEL_HWND) = None;
+    }
 }
 
 pub fn init<F>(callback: F) -> Result<(), String>
@@ -507,18 +526,14 @@ where
                     if win.shown() {
                         win.hide();
                     }
-                    UI_VISIBLE.store(false, Ordering::SeqCst);
-                    if let Some(callback) = ui_callback() {
-                        callback(UiEvent::Hidden);
-                    }
+                    emit_hidden_once();
                     true
                 }
                 Event::KeyDown if app::event_key() == Key::Escape => {
-                    win.hide();
-                    UI_VISIBLE.store(false, Ordering::SeqCst);
-                    if let Some(callback) = ui_callback() {
-                        callback(UiEvent::Hidden);
+                    if win.shown() {
+                        win.hide();
                     }
+                    emit_hidden_once();
                     true
                 }
                 Event::Resize => {
@@ -686,6 +701,13 @@ where
                             options.physical_width,
                             options.physical_height,
                         ));
+                        // FLTK 每次 Show 重建 OS 窗口：先刷新句柄再置可见
+                        // 标志，保证 is_visible() 为真时句柄必已就绪
+                        #[cfg(target_os = "windows")]
+                        {
+                            *lock_or_recover(&PANEL_HWND) =
+                                Some(window.raw_handle() as isize);
+                        }
                         UI_VISIBLE.store(true, Ordering::SeqCst);
                     }
                     Command::Hide => {
@@ -693,7 +715,10 @@ where
                             window.hide();
                         }
                         *lock_or_recover(&PANEL_BOUNDS) = None;
-                        UI_VISIBLE.store(false, Ordering::SeqCst);
+                        // 与事件分支共用同一去重回调：win.hide() 的 FL_HIDE
+                        // 重入先落地一次，此处交换为 no-op；重入时机变化时
+                        // 由此处落地——无论哪侧执行都恰好一次
+                        emit_hidden_once();
                     }
                 }
             }
@@ -732,6 +757,13 @@ pub fn hide() -> Result<(), String> {
 
 pub fn is_visible() -> bool {
     UI_VISIBLE.load(Ordering::SeqCst)
+}
+
+// 面板窗口当前的原生句柄：面板可见期间有效（Show 时在 FLTK 线程刷新、
+// 先于 UI_VISIBLE 置位），隐藏落地后为 None。粘贴模块据此以精确句柄
+// 判定「面板隐藏是否留下待完成的前台切换」
+pub fn panel_hwnd() -> Option<isize> {
+    *lock_or_recover(&PANEL_HWND)
 }
 
 pub fn contains_point(x: i32, y: i32) -> bool {

--- a/src-tauri/src/services/low_memory/manager.rs
+++ b/src-tauri/src/services/low_memory/manager.rs
@@ -255,14 +255,52 @@ fn log_auto_low_memory_state(next_state: AutoLowMemoryLogState) {
 
 // 销毁所有 WebView 窗口
 fn destroy_all_webviews(app: &AppHandle) {
-    for (label, window) in app.webview_windows() {
-        if label.starts_with("pin-image-") {
-            let _ = window.destroy();
+    // 销毁集（本函数实际销毁的窗口）：埋点过滤与销毁循环共享同一谓词、
+    // 单点定义——新增窗口类时不会出现「销毁循环改了、埋点过滤漏改」的
+    // 漂移；持前台的窗口被销毁却无埋点会使粘贴跨切换注入、修饰键卡住
+    // 静默复发（issue #496）
+    let in_destroy_set =
+        |label: &str| label.starts_with("pin-image-") || WEBVIEW_LABELS.contains(&label);
+
+    // 直接销毁可能仍持前台的可见主窗口同样会异步引发前台切换（issue #496）；
+    // 该路径不走 set_window_state / hide_main_window，需在此自行埋点。
+    // 仅当即将销毁的某个窗口恰持前台时、其销毁才留下待完成的切换，才
+    // 埋点——receive-box 等本进程存活窗口不在销毁集内，不可用「前台
+    // 属于本进程」猜测：猜测误判导致粘贴白等 300ms
+    #[cfg(target_os = "windows")]
+    {
+        use windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow;
+
+        let foreground_val = unsafe {
+            let foreground = GetForegroundWindow();
+            if foreground.0.is_null() {
+                0
+            } else {
+                foreground.0 as isize
+            }
+        };
+        // 前台为空说明正处于某次切换的中间态，而销毁尚未执行、该切换
+        // 并非本次销毁引发——跳过埋点，不把等待挂到无关切换的落定上。
+        // 与 note_own_window_hidden 前台为空时保守等待的差异源自时序：
+        // 此处埋点必先于销毁执行，中间态不可能由本次销毁引发；彼处的
+        // 调用方可能在隐藏落地后埋点，中间态可能正是本次隐藏引发的切换
+        if foreground_val != 0 {
+            let hidden_hwnd = app
+                .webview_windows()
+                .into_iter()
+                .filter(|(label, _)| in_destroy_set(label.as_str()))
+                .filter_map(|(_, window)| {
+                    window.hwnd().ok().map(|hwnd| hwnd.0 as isize)
+                })
+                .find(|hwnd| *hwnd == foreground_val);
+            if let Some(hwnd) = hidden_hwnd {
+                crate::services::paste::keyboard::note_own_window_hidden(Some(hwnd));
+            }
         }
     }
 
-    for label in WEBVIEW_LABELS {
-        if let Some(window) = app.get_webview_window(label) {
+    for (label, window) in app.webview_windows() {
+        if in_destroy_set(label.as_str()) {
             let _ = window.destroy();
         }
     }

--- a/src-tauri/src/services/low_memory/panel.rs
+++ b/src-tauri/src/services/low_memory/panel.rs
@@ -50,7 +50,18 @@ pub fn init_panel(app: AppHandle) -> Result<(), String> {
                 }
             });
         }
-        UiEvent::Hidden => {}
+        UiEvent::Hidden => {
+            // 面板隐藏回调（ESC / 失焦自隐藏，及 hide_panel 的隐藏落地时刻）：
+            // 插件侧已按可见→隐藏转换去重，每次隐藏只回调一次（此前
+            // win.hide() 的 FL_HIDE 重入与外层分支会各发一次，第二次以
+            // HWND 销毁后的前台快照覆盖第一次）。面板隐藏会异步引发前台
+            // 切换：以面板自身句柄通知粘贴模块，仅在其此刻仍持前台时
+            // 记录等待（issue #496）
+            #[cfg(target_os = "windows")]
+            crate::services::paste::keyboard::note_own_window_hidden(
+                low_memory_fltk::panel_hwnd(),
+            );
+        }
     })
 }
 
@@ -136,6 +147,11 @@ fn show_panel_at_current_page(position_override: Option<PanelPosition>) -> Resul
         state.last_position = Some(position);
     }
 
+    // 面板（重新）显示：此前隐藏留下的「待完成前台切换」不再成立（面板将
+    // 重获前台），清除埋点，随后的粘贴序列不再等待该切换、保持零等待
+    #[cfg(target_os = "windows")]
+    crate::services::paste::keyboard::clear_own_window_hidden_pending();
+
     low_memory_fltk::show(ShowOptions {
         items: page.items,
         footer_text: format!(
@@ -215,6 +231,21 @@ fn build_position(height_logical: i32) -> Result<PanelPosition, String> {
 
 pub fn hide_panel() -> Result<(), String> {
     PANEL_PAGE_STATE.lock().last_position = None;
+    // 面板可见才真正隐藏、才可能引发前台切换（issue #496）：不可见时
+    // （进入/退出低占用模式会对已隐藏面板无条件调用）不埋点，避免
+    // 覆盖既有挂起埋点。此处在隐藏请求时刻以面板真实句柄埋点，覆盖
+    // 命令送达 FLTK 线程（16ms 循环）前的间隙；隐藏落地时
+    // UiEvent::Hidden 回调（已去重为单次）以更接近落地时刻的前台
+    // 复核——两次都以同一面板句柄比对、仅在其仍持前台时记录，
+    // 方向恒一致
+    #[cfg(target_os = "windows")]
+    {
+        if low_memory_fltk::is_visible() {
+            crate::services::paste::keyboard::note_own_window_hidden(
+                low_memory_fltk::panel_hwnd(),
+            );
+        }
+    }
     low_memory_fltk::hide()
 }
 

--- a/src-tauri/src/services/paste/keyboard.rs
+++ b/src-tauri/src/services/paste/keyboard.rs
@@ -5,7 +5,13 @@ use enigo::{Enigo, Direction, Key, Keyboard, Settings};
 use windows::Win32::UI::Input::KeyboardAndMouse::{
     GetAsyncKeyState, SendInput, INPUT, INPUT_KEYBOARD, KEYBDINPUT,
     KEYBD_EVENT_FLAGS, KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP, VK_INSERT, VK_MENU,
-    VK_CONTROL, VK_SHIFT, VK_V,
+    VK_CONTROL, VK_LWIN, VK_RWIN, VK_SHIFT, VK_V,
+};
+#[cfg(target_os = "windows")]
+use windows::Win32::System::Threading::GetCurrentProcessId;
+#[cfg(target_os = "windows")]
+use windows::Win32::UI::WindowsAndMessaging::{
+    GetForegroundWindow, GetWindowThreadProcessId,
 };
 
 #[cfg(target_os = "windows")]
@@ -13,25 +19,15 @@ fn is_key_pressed(vk: u16) -> bool {
     unsafe { GetAsyncKeyState(vk as i32) < 0 }
 }
 
+// 注入单个按键事件，返回是否成功；SendInput 返回 0 表示事件被系统阻塞
+// （如向高完整性前台窗口注入时被 UIPI 拦截；返回值不区分具体原因）
 #[cfg(target_os = "windows")]
-fn send_key(vk: u16, up: bool) {
-    let input = INPUT {
-        r#type: INPUT_KEYBOARD,
-        Anonymous: windows::Win32::UI::Input::KeyboardAndMouse::INPUT_0 {
-            ki: KEYBDINPUT {
-                wVk: windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY(vk),
-                wScan: 0,
-                dwFlags: if up { KEYEVENTF_KEYUP } else { KEYBD_EVENT_FLAGS(0) },
-                time: 0,
-                dwExtraInfo: crate::services::system::raw_input::PASTE_INPUT_MARKER,
-            },
-        },
-    };
-    unsafe { SendInput(&[input], std::mem::size_of::<INPUT>() as i32); }
+fn send_key(vk: u16, up: bool) -> bool {
+    send_key_ex(vk, up, false)
 }
 
 #[cfg(target_os = "windows")]
-fn send_key_ex(vk: u16, up: bool, extended: bool) {
+fn send_key_ex(vk: u16, up: bool, extended: bool) -> bool {
     let mut flags = if up { KEYEVENTF_KEYUP } else { KEYBD_EVENT_FLAGS(0) };
     if extended {
         flags |= KEYEVENTF_EXTENDEDKEY;
@@ -48,17 +44,69 @@ fn send_key_ex(vk: u16, up: bool, extended: bool) {
             },
         },
     };
-    unsafe { SendInput(&[input], std::mem::size_of::<INPUT>() as i32); }
+    unsafe { SendInput(&[input], std::mem::size_of::<INPUT>() as i32) == 1 }
 }
 
 #[cfg(target_os = "windows")]
 use std::sync::Mutex;
+#[cfg(target_os = "windows")]
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
 #[cfg(target_os = "windows")]
 static CURRENT_TRIGGER_KEY: Mutex<Option<u16>> = Mutex::new(None);
 
 #[cfg(target_os = "windows")]
 static PASTE_SIMULATION_LOCK: Mutex<()> = Mutex::new(());
+
+// 释放注入被前台高完整性窗口拦截而卡住的粘贴主键（V/Insert）：主键 down
+// 已送达、up 被拦时逻辑卡住。raw_input 只跟踪修饰键物理态，主键无法像
+// 修饰键那样比对物理状态，但序列结束后主键本就该处于抬起状态，直接由
+// 前台切换回调重试释放。单槽即可：先后卡住不同主键（V 与 Insert 分属两
+// 种粘贴模式，切换必经设置页、必引发前台切换自愈）实际不可达，槽位覆盖
+// 被自愈先行阻断
+#[cfg(target_os = "windows")]
+static STUCK_PASTE_KEY: Mutex<Option<u16>> = Mutex::new(None);
+
+// 等待挂起前台切换完成的上限：前台切换通常在数十毫秒内完成，300ms 兜底
+#[cfg(target_os = "windows")]
+const FOREGROUND_SWITCH_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_millis(300);
+
+// 「刚隐藏」判定窗口：埋点与随后的注入之间除百毫秒级 sleep 外，还有
+// 数据库读取与剪贴板写入等 IO（大条目、慢盘可超过 1 秒），取 3 秒覆盖
+// 慢路径。过期只导致「该等而没等」（退回卡键检测兜底），不会引入误
+// 等待——等待条件仍要求前台尚未离开被隐藏窗口（见 wait_foreground_switch）
+#[cfg(target_os = "windows")]
+const OWN_WINDOW_HIDE_RECENT: std::time::Duration = std::time::Duration::from_secs(3);
+
+// 本进程前台窗口（主窗口、低内存面板）最近一次「确有前台切换待完成」的
+// 隐藏记录：wait_away 为需等待离开的前台窗口句柄（0 表示前台为空、等待
+// 其落定）。隐藏若发生在该窗口仍处于前台时，Windows 会异步切换前台，随
+// 后的粘贴序列需等待切换完成再注入，避免序列跨过切换时刻造成「前段注入
+// 成功、后段被 UIPI 拦截」的修饰键卡住（issue #496）。仅在被隐藏窗口
+// 恰持前台时才记录（见 note_own_window_hidden），无待完成切换的隐藏
+// 不入账。时刻用 Instant 单调钟而非 SystemTime 墙钟，避免系统校时
+// 回拨导致误判
+#[cfg(target_os = "windows")]
+static LAST_OWN_WINDOW_HIDE: Mutex<Option<HideNote>> = Mutex::new(None);
+
+// LAST_OWN_WINDOW_HIDE 的条目：隐藏时刻 + 已确认待离开的前台窗口句柄
+#[cfg(target_os = "windows")]
+struct HideNote {
+    hidden_at: std::time::Instant,
+    wait_away: isize,
+}
+
+// raw_input 物理修饰键状态不可用的提示只记录一次，避免在前台切换回调里刷屏
+#[cfg(target_os = "windows")]
+static PHYSICAL_STATE_MISSING_LOGGED: AtomicBool = AtomicBool::new(false);
+
+// 最近一次释放注入仍被拦截的卡住修饰键集合（位掩码，bit 下标与
+// entries() 遍历顺序一致，仅在 release_stuck_modifiers 内读写）：用于
+// 卡键日志去重，卡键未愈期间前台切换回调的重试不再逐次刷屏；释放成功
+// 即清除，同键再次卡住按新状态重新记录
+#[cfg(target_os = "windows")]
+static STUCK_MODIFIERS_LOGGED: AtomicU8 = AtomicU8::new(0);
 
 #[cfg(target_os = "windows")]
 pub fn set_trigger_key_from_shortcut(shortcut: &str) {
@@ -130,25 +178,93 @@ impl ModifierState {
             ctrl: is_key_pressed(VK_CONTROL.0),
             shift: is_key_pressed(VK_SHIFT.0),
             alt: is_key_pressed(VK_MENU.0),
-            lwin: is_key_pressed(0x5B),
-            rwin: is_key_pressed(0x5C),
+            lwin: is_key_pressed(VK_LWIN.0),
+            rwin: is_key_pressed(VK_RWIN.0),
         }
     }
 
+    // (vk, 该键在本状态中是否按下)，顺序与 raw_input 物理态元组一致：
+    // Ctrl / Shift / Alt / LWin / RWin。release_stuck_modifiers 依赖逻辑态
+    // 与物理态按同一顺序对齐，禁止单独调整任一侧的顺序
+    fn entries(&self) -> [(u16, bool); 5] {
+        [
+            (VK_CONTROL.0, self.ctrl),
+            (VK_SHIFT.0, self.shift),
+            (VK_MENU.0, self.alt),
+            (VK_LWIN.0, self.lwin),
+            (VK_RWIN.0, self.rwin),
+        ]
+    }
+
+    // 释放被卡住的修饰键（逻辑按下、物理已释放——注入的 up 被 UIPI 拦截所致，
+    // 会导致回车/方向键全局失效、快捷键失配，issue #496）。
+    // 读序说明：先读物理（raw_input 原子量）再读逻辑（GetAsyncKeyState）。
+    // 逻辑读取同步反映物理按键，物理原子量经 raw_input 线程更新存在毫秒级滞后，
+    // 两次读取之间用户恰好按下物理键时存在理论上的误判窗口；所有调用点
+    // （粘贴序列结束、前台切换回调）与用户按键时刻基本错开，风险可忽略。
+    // 已知边界：若 raw_input 线程长时间阻塞导致原子量持久过期，此处会把
+    // 用户正按着的修饰键误判为卡住并抬起；根治需为物理态增加新鲜度校验，
+    // 留待后续
+    fn release_stuck_modifiers() {
+        let Some(physical) = Self::physical() else {
+            // raw_input 未启动或初始化失败时物理态不可用，卡键检测与自愈
+            // 整体失效；只提示一次，便于诊断
+            if !PHYSICAL_STATE_MISSING_LOGGED.swap(true, Ordering::Relaxed) {
+                eprintln!("[paste] raw_input 物理修饰键状态不可用，卡键检测与自愈失效");
+            }
+            return;
+        };
+        let logical = Self::record();
+        // 日志去重（对齐 PHYSICAL_STATE_MISSING_LOGGED 的设计意图）：卡键
+        // 未愈期间前台切换回调每次都会进入此函数，逐次打印「检测到」与
+        // 「被拦截」构成刷屏。仅当某键的卡住状态是新出现时记录检测与拦截
+        // 日志、重试期间静默，释放成功（且此前记录过卡住）时补一条成功
+        // 日志、去重位随即清除——与主键自愈（retry_stuck_paste_key）的
+        // 成功日志对称
+        let prev_logged = STUCK_MODIFIERS_LOGGED.load(Ordering::Relaxed);
+        let mut logged = 0u8;
+        for (index, ((vk, logical_down), (_, physical_down))) in logical
+            .entries()
+            .into_iter()
+            .zip(physical.entries())
+            .enumerate()
+        {
+            if logical_down && !physical_down {
+                if prev_logged & (1 << index) == 0 {
+                    eprintln!("[paste] 检测到卡住的修饰键 vk=0x{:X}，尝试释放", vk);
+                }
+                if !send_key(vk, true) {
+                    // 释放注入仍被拦截（前台还是高完整性窗口）：由前台切换
+                    // 事件回调（focus.rs）在前台切回可注入窗口后重试释放。
+                    // 仍卡住才置位去重：释放成功即清除，同键再次卡住按
+                    // 新状态重新记录
+                    logged |= 1 << index;
+                    if prev_logged & (1 << index) == 0 {
+                        eprintln!(
+                            "[paste] 卡住的修饰键 vk=0x{:X} 释放注入被拦截，等待前台切换后重试",
+                            vk
+                        );
+                    }
+                } else if prev_logged & (1 << index) != 0 {
+                    eprintln!("[paste] 卡住的修饰键 vk=0x{:X} 已在前台切换后释放", vk);
+                }
+            }
+        }
+        STUCK_MODIFIERS_LOGGED.store(logged, Ordering::Relaxed);
+    }
+
+    // 释放与粘贴快捷键冲突的修饰键（Ctrl/Shift/Win）。Alt 不在此处释放：
+    // 调用方需先释放触发键再释放 Alt，顺序有语义，勿并入。基于 entries()
+    // 遍历，与 apply / release_stuck_modifiers 共享同一键序
     fn release_conflicting(&self) {
-        if self.ctrl {
-            send_key(VK_CONTROL.0, true);
+        let mut released = false;
+        for (vk, pressed) in self.entries() {
+            if pressed && vk != VK_MENU.0 {
+                send_key(vk, true);
+                released = true;
+            }
         }
-        if self.shift {
-            send_key(VK_SHIFT.0, true);
-        }
-        if self.lwin {
-            send_key(0x5B, true);
-        }
-        if self.rwin {
-            send_key(0x5C, true);
-        }
-        if self.ctrl || self.shift || self.lwin || self.rwin {
+        if released {
             std::thread::sleep(std::time::Duration::from_millis(10));
         }
     }
@@ -166,11 +282,9 @@ impl ModifierState {
     }
 
     fn apply(&self) {
-        Self::set_key_state(VK_CONTROL.0, self.ctrl);
-        Self::set_key_state(VK_SHIFT.0, self.shift);
-        Self::set_key_state(VK_MENU.0, self.alt);
-        Self::set_key_state(0x5B, self.lwin);
-        Self::set_key_state(0x5C, self.rwin);
+        for (vk, pressed) in self.entries() {
+            Self::set_key_state(vk, pressed);
+        }
     }
 
     fn set_key_state(vk: u16, pressed: bool) {
@@ -186,6 +300,152 @@ impl ModifierState {
                 std::thread::sleep(std::time::Duration::from_millis(2));
             }
         }
+        // 序列结束后校验并解除卡键（issue #496）：立即尝试一次；若释放
+        // 注入仍被前台高完整性窗口持续拦截（UIPI），由前台切换事件回调
+        // （focus.rs 的 try_release_stuck_keys）在前台切到可注入
+        // 窗口后自动重试释放，无需轮询、无时间上限
+        Self::release_stuck_modifiers();
+    }
+}
+
+// 前台切换事件回调：此刻前台已切换到新窗口，卡键释放注入不再被旧前台
+// 拦截，重试一次；粘贴序列进行中（锁被持有）时让位，不打扰其修饰键
+// 记录与恢复
+#[cfg(target_os = "windows")]
+pub(crate) fn try_release_stuck_keys() {
+    if let Ok(_guard) = PASTE_SIMULATION_LOCK.try_lock() {
+        ModifierState::release_stuck_modifiers();
+        retry_stuck_paste_key();
+    }
+}
+
+// 重试释放卡住的粘贴主键：主键无物理态可比对（raw_input 只跟踪修饰键），
+// 以「逻辑仍按下且所属序列已结束」判定卡住。已知边界：用户恰在此刻物理
+// 按着该主键时会误抬一次，概率与修饰键自愈的理论误判窗口同级，可忽略。
+// 释放仍被拦截则保留记录，等待下一次前台切换重试
+#[cfg(target_os = "windows")]
+fn retry_stuck_paste_key() {
+    let mut stuck = STUCK_PASTE_KEY
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    let Some(vk) = *stuck else {
+        return;
+    };
+    if !is_key_pressed(vk) {
+        // 逻辑已不在按下状态（用户物理按过该键、或状态已自行恢复）
+        *stuck = None;
+        return;
+    }
+    if send_key(vk, true) {
+        eprintln!("[paste] 卡住的粘贴主键 vk=0x{:X} 已在前台切换后释放", vk);
+        *stuck = None;
+    }
+}
+
+// 前台窗口是否属于本进程；查询失败（窗口销毁中）也按本进程处理——
+// 销毁本身就会引发前台切换，等待其完成更安全
+#[cfg(target_os = "windows")]
+fn foreground_belongs_to_own_process(foreground: windows::Win32::Foundation::HWND) -> bool {
+    let mut process_id: u32 = 0;
+    unsafe {
+        GetWindowThreadProcessId(foreground, Some(&mut process_id)) == 0
+            || process_id == GetCurrentProcessId()
+    }
+}
+
+// 等待挂起的前台切换完成（issue #496）：隐藏仍处于前台的窗口后，Windows
+// 异步切换前台；若注入序列跨过切换时刻，会出现「前段注入成功、后段被
+// UIPI 拦截」的不对称。wait_away 为需等待离开的窗口句柄（0 表示前台为
+// 空、等待其落定即可）。超时后放行——此时注入可能落在本进程窗口上导致
+// 粘贴未生效，但整段序列同生共死，不会卡住修饰键；序列中段前台仍可能
+// 被第三方切换（抢焦点弹窗等），残余情况由卡键检测兜底
+#[cfg(target_os = "windows")]
+fn wait_foreground_switch(wait_away: isize) {
+    // 不以「窗口已重新可见」短路放行：隐藏经 Tauri 主线程异步派发，埋点
+    // 记录时窗口可能尚未真正隐藏，可见性无法区分「已重新显示」（无待完
+    // 成切换）与「隐藏未落地」（恰恰需要等待）——后者误放行会让注入序列
+    // 跨过随后的隐藏落地与前台切换，重现「前段注入成功、后段被 UIPI 拦
+    // 截」的不对称。重新显示场景改由显示路径清除埋点处理
+    // （clear_own_window_hidden_pending），此处只认定一个事实：前台离开
+    // 被隐藏窗口即切换完成
+    let deadline = std::time::Instant::now() + FOREGROUND_SWITCH_TIMEOUT;
+    while std::time::Instant::now() < deadline {
+        unsafe {
+            let foreground = GetForegroundWindow();
+            let foreground_val = foreground.0 as isize;
+            // 前台已离开被隐藏窗口即切换完成。若前台仍等于该句柄值但已
+            // 不属于本进程，说明被隐藏窗口销毁后（如进入低占用模式时
+            // destroy_all_webviews）句柄值被其他进程的新窗口复用且恰为
+            // 前台——原窗口引发的前台切换早已完成，等待无意义，同样放行
+            if foreground_val != 0
+                && (foreground_val != wait_away
+                    || !foreground_belongs_to_own_process(foreground))
+            {
+                return;
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+}
+
+// 记录本进程前台窗口（主窗口、低内存面板）刚隐藏：随后的
+// 粘贴序列需等待前台切换完成再注入，避免序列跨越切换时刻造成修饰键卡住
+// （issue #496）。hidden_hwnd 为被隐藏窗口的句柄（未知时传 None）：仅当
+// 该窗口此刻仍持前台、确有切换待完成时才记录等待；其余情况（前台已在
+// 别处——如粘贴目标为本进程其他存活窗口、或句柄未知）一律不记录——
+// 既不覆盖可能仍挂起的既有埋点，也不以「前台属于本进程」猜测被隐藏
+// 窗口：receive-box 等本进程存活窗口不在隐藏之列，猜测会把它们误当作
+// 被隐藏窗口、导致粘贴白等满 300ms
+#[cfg(target_os = "windows")]
+pub(crate) fn note_own_window_hidden(hidden_hwnd: Option<isize>) {
+    let wait_away = unsafe {
+        let foreground = GetForegroundWindow();
+        if foreground.0.is_null() {
+            // 前台为空：正处于某次切换的中间态。埋点可能在隐藏落地后
+            // 调用（面板 UiEvent::Hidden 回调），此刻的中间态可能正是
+            // 本次隐藏引发的切换，保守等待其落定再注入；埋点必先于
+            // 隐藏/销毁落地的调用方（destroy_all_webviews）以各自守卫
+            // 跳过，不会进入此分支
+            0
+        } else {
+            match hidden_hwnd {
+                Some(hidden) if hidden == foreground.0 as isize => hidden,
+                _ => return,
+            }
+        }
+    };
+    *LAST_OWN_WINDOW_HIDE
+        .lock()
+        .unwrap_or_else(|error| error.into_inner()) = Some(HideNote {
+        hidden_at: std::time::Instant::now(),
+        wait_away,
+    });
+}
+
+// 窗口重新显示（主窗口 show_main_window、低内存面板）：此前隐藏留下的
+// 「待完成前台切换」不再成立——窗口将重获前台或切换已被打断，清除埋点，
+// 随后的粘贴序列不再等待（注入落在本进程窗口上是明示接受的设计场景）。
+// 与以可见性短路放行相比，显示路径的清除是确定性信号：隐藏未落地时窗口
+// 不会走显示路径，埋点必然保留、等待照常进行
+#[cfg(target_os = "windows")]
+pub(crate) fn clear_own_window_hidden_pending() {
+    *LAST_OWN_WINDOW_HIDE
+        .lock()
+        .unwrap_or_else(|error| error.into_inner()) = None;
+}
+
+// 若最近刚隐藏过本进程前台窗口且该隐藏留下了待完成的前台切换，
+// 返回需等待离开的窗口句柄；否则返回 None（无需等待）
+#[cfg(target_os = "windows")]
+fn pending_foreground_switch() -> Option<isize> {
+    let last = LAST_OWN_WINDOW_HIDE
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    match last.as_ref() {
+        Some(note) if note.hidden_at.elapsed() < OWN_WINDOW_HIDE_RECENT => {
+            Some(note.wait_away)
+        }
+        _ => None,
     }
 }
 
@@ -197,7 +457,16 @@ pub fn simulate_paste() -> Result<(), String> {
         .lock()
         .unwrap_or_else(|error| error.into_inner());
     let settings = crate::get_settings();
-    
+
+    // 本进程窗口（主窗口、低内存面板）隐藏引发的前台切换
+    // 是异步的，等待切换完成让注入序列完整落在同一个前台窗口上，避免
+    // 「前段注入成功、后段被 UIPI 拦截」的不对称造成修饰键卡住（issue
+    // #496）。仅在该隐藏留下了待完成的前台切换时等待；热键直粘、pin
+    // 模式、粘贴目标为本进程窗口（如文本编辑器）等场景不等待、不增加延迟
+    if let Some(wait_away) = pending_foreground_switch() {
+        wait_foreground_switch(wait_away);
+    }
+
     if settings.paste_shortcut_mode == "ctrl_v" {
         simulate_paste_ctrl_v()
     } else {
@@ -205,47 +474,82 @@ pub fn simulate_paste() -> Result<(), String> {
     }
 }
 
-// Shift+Insert 粘贴：记录修饰键 → 释放冲突键 → 纯净粘贴 → 对齐物理状态
+// 粘贴序列：记录修饰键 → 释放冲突键 → 纯净注入 → 对齐物理状态。
+// 修饰键按下被拦截（UIPI）时放弃本次注入：整段序列同生共死，继续注入
+// 没有意义，中止并记录日志便于诊断；修饰键释放侧被拦截由序列末的卡键
+// 检测与前台切换回调自愈，主键释放侧被拦截由 STUCK_PASTE_KEY 记录、
+// 前台切换回调重试释放（issue #496）
 #[cfg(target_os = "windows")]
-fn simulate_paste_shift_insert() -> Result<(), String> {
+fn run_paste_sequence(modifier_vk: u16, key_vk: u16, key_extended: bool) {
     let mods = ModifierState::record();
     mods.release_conflicting();
     if let Some(vk) = take_trigger_key() {
+        // 触发键是用户物理按下的键（setter 只在热键触发路径调用），其 up
+        // 注入即使被 UIPI 拦截，用户松手时的物理 up 也会清除逻辑状态，
+        // 不存在永久卡键，无需检测与自愈
         send_key(vk, true);
     }
     if mods.alt {
         send_key(VK_MENU.0, true);
     }
 
-    send_key(VK_SHIFT.0, false);
-    send_key_ex(VK_INSERT.0, false, true);
-    std::thread::sleep(std::time::Duration::from_millis(8));
-    send_key_ex(VK_INSERT.0, true, true);
-    send_key(VK_SHIFT.0, true);
+    if send_key(modifier_vk, false) {
+        if send_key_ex(key_vk, false, key_extended) {
+            std::thread::sleep(std::time::Duration::from_millis(8));
+            if !send_key_ex(key_vk, true, key_extended) {
+                // 主键释放被拦截（如序列中段前台被切到高完整性窗口）：down 已
+                // 送达、up 被拦，主键逻辑态卡住。无修饰键类的全局副作用，也
+                // 不会持续 autorepeat——自动重复由键盘硬件对物理按键生成，
+                // 注入的单次 down 不触发；实际影响是污染 GetAsyncKeyState
+                // 查询方、该键后续物理按下可能被应用计为 repeat。记录后由
+                // 前台切换回调重试释放（issue #496）
+                *STUCK_PASTE_KEY
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner()) = Some(key_vk);
+                eprintln!(
+                    "[paste] 主键 vk=0x{:X} 释放注入被拦截，等待前台切换后重试释放",
+                    key_vk
+                );
+            }
+        } else {
+            // 主键按下被拦截：主键未进入按下状态，再注入释放是对未按下键的
+            // 幽灵事件，且会把从未按下的键误记入卡键自愈槽位、留下「down 已
+            // 送达」的失实日志，污染最关键失败场景的诊断——跳过释放注入。
+            // 修饰键释放仍照常进行（其被拦由卡键检测兜底），记录日志便于诊断
+            eprintln!("[paste] 主键 vk=0x{:X} 按下注入被拦截，跳过释放注入", key_vk);
+        }
+        if !send_key(modifier_vk, true) {
+            // 释放注入被拦截（如序列中段前台被切到高完整性窗口）：修饰键
+            // 卡在按下状态，由序列末的卡键检测立即尝试释放、前台切换
+            // 回调兜底重试（issue #496）
+            eprintln!(
+                "[paste] 修饰键 vk=0x{:X} 释放注入被拦截，等待卡键检测自愈",
+                modifier_vk
+            );
+        }
+    } else {
+        // 按下注入被拦截（UIPI 等）：中止后续序列，粘贴未发生，记录日志
+        // 便于诊断（issue #496）
+        eprintln!(
+            "[paste] 修饰键 vk=0x{:X} 按下注入被拦截，中止本次粘贴序列",
+            modifier_vk
+        );
+    }
 
     mods.restore_current_physical();
+}
+
+// Shift+Insert 粘贴
+#[cfg(target_os = "windows")]
+fn simulate_paste_shift_insert() -> Result<(), String> {
+    run_paste_sequence(VK_SHIFT.0, VK_INSERT.0, true);
     Ok(())
 }
 
-// Ctrl+V 粘贴：记录修饰键 → 释放冲突键 → 纯净粘贴 → 对齐物理状态
+// Ctrl+V 粘贴
 #[cfg(target_os = "windows")]
 fn simulate_paste_ctrl_v() -> Result<(), String> {
-    let mods = ModifierState::record();
-    mods.release_conflicting();
-    if let Some(vk) = take_trigger_key() {
-        send_key(vk, true);
-    }
-    if mods.alt {
-        send_key(VK_MENU.0, true);
-    }
-    send_key(VK_CONTROL.0, false);
-
-    send_key(VK_V.0, false);
-    std::thread::sleep(std::time::Duration::from_millis(8));
-    send_key(VK_V.0, true);
-    send_key(VK_CONTROL.0, true);
-
-    mods.restore_current_physical();
+    run_paste_sequence(VK_CONTROL.0, VK_V.0, false);
     Ok(())
 }
 

--- a/src-tauri/src/services/system/focus.rs
+++ b/src-tauri/src/services/system/focus.rs
@@ -239,17 +239,23 @@ unsafe extern "system" fn focus_callback(
 ) {
     use windows::Win32::UI::WindowsAndMessaging::{GetForegroundWindow, GetClassNameW, GetWindowTextW};
 
+    let hwnd = GetForegroundWindow();
+    if hwnd.0.is_null() {
+        return;
+    }
+
+    // 前台已切换到新窗口：重试释放被上一个前台（高完整性窗口）拦截的
+    // 修饰键与粘贴主键 up 注入（issue #496 卡键自愈；粘贴序列进行中时
+    // 自动让位）。须位于低内存早退之前：低内存面板可见期间的前台切换
+    // 同样需要自愈
+    crate::services::paste::keyboard::try_release_stuck_keys();
+
     if crate::services::low_memory::is_low_memory_mode()
         && crate::services::low_memory::is_panel_visible()
     {
         return;
     }
 
-    let hwnd = GetForegroundWindow();
-    if hwnd.0.is_null() {
-        return;
-    }
-    
     let hwnd_val = hwnd.0 as isize;
 
     if EXCLUDED_HWNDS.lock().contains(&hwnd_val) {

--- a/src-tauri/src/services/system/raw_input.rs
+++ b/src-tauri/src/services/system/raw_input.rs
@@ -180,6 +180,18 @@ mod windows_raw_input {
                 return;
             }
 
+            // 校准物理修饰键初始状态（issue #496 审查发现）：原子量纯事件驱动，
+            // 用户在注册前已按住的修饰键（如开机自启时正按着组合键）永远不会
+            // 产生事件，物理态将持续误报为抬起，卡键检测会把用户正按着的修饰
+            // 键误判为卡住并注入释放。以注册成功后的异步键态快照补齐初值；
+            // 校准先于消息循环执行，注册后到来的物理事件（含已排队者）按序
+            // 覆盖快照，任何交错下终态均正确
+            CTRL_DOWN.store(is_vk_pressed(VK_CONTROL_CODE), Ordering::Relaxed);
+            SHIFT_DOWN.store(is_vk_pressed(VK_SHIFT_CODE), Ordering::Relaxed);
+            ALT_DOWN.store(is_vk_pressed(VK_MENU_CODE), Ordering::Relaxed);
+            LWIN_DOWN.store(is_vk_pressed(VK_LWIN_CODE), Ordering::Relaxed);
+            RWIN_DOWN.store(is_vk_pressed(VK_RWIN_CODE), Ordering::Relaxed);
+
             println!("[RawInput] Raw Input 已启动");
 
             let mut msg = MSG::default();

--- a/src-tauri/src/windows/main_window/visibility.rs
+++ b/src-tauri/src/windows/main_window/visibility.rs
@@ -34,6 +34,11 @@ pub fn show_main_window(window: &WebviewWindow) {
         return;
     }
 
+    // 主窗口重新显示：此前隐藏留下的「待完成前台切换」不再成立（窗口将
+    // 重获前台），清除埋点，随后的粘贴序列不再等待该切换、保持零等待
+    #[cfg(target_os = "windows")]
+    crate::services::paste::keyboard::clear_own_window_hidden_pending();
+
     let state = super::state::get_window_state();
 
     if state.is_snapped && state.is_hidden {
@@ -271,6 +276,15 @@ fn hide_normal_window(window: &WebviewWindow) {
     }
 
     let _ = window.hide();
+    // 主窗口刚隐藏（若此刻仍持前台，Windows 会异步切换前台）：通知粘贴模块，
+    // 下一个粘贴序列需等待切换完成再注入（issue #496）。带句柄埋点可区分
+    // 「被隐藏窗口仍持前台」与「前台已在别处」（如粘贴目标为本进程窗口），
+    // 后者无需等待。贴边隐藏（snap.rs）只移出屏幕不真正隐藏、不引发前台
+    // 切换，无需埋点
+    #[cfg(target_os = "windows")]
+    crate::services::paste::keyboard::note_own_window_hidden(
+        window.hwnd().map(|hwnd| hwnd.0 as isize).ok(),
+    );
     set_window_state(WindowState::Hidden);
     crate::services::memory::schedule_cleanup_after_main_window_hide();
 

--- a/src-tauri/src/windows/quickpaste/manager.rs
+++ b/src-tauri/src/windows/quickpaste/manager.rs
@@ -70,6 +70,9 @@ pub fn show_quickpaste_window(app: &AppHandle) -> Result<(), String> {
 pub fn hide_quickpaste_window(app: &AppHandle) -> Result<(), String> {
     disable_quickpaste_keyboard_mode();
     if let Some(window) = app.get_webview_window("quickpaste") {
+        // 此处无需隐藏埋点（note_own_window_hidden）：便捷粘贴窗口以
+        // focusable(false) 创建、从不持有前台，隐藏不会引发前台切换，
+        // 粘贴注入时目标窗口本就是前台，不存在跨切换的不对称
         let _ = window.hide();
     }
     set_visible(false);


### PR DESCRIPTION
Closes #496

## 问题

非管理员运行 QC 时，在 3ds Max 2024「另存为」对话框的文件名输入框按 Win+V：剪贴板调不出，随后回车、方向键全局失效，设置页和托盘右键也无响应，只能结束进程恢复。群友补充的复现顺序更精确：先在网页用 Win+V 正常粘贴一次，再到该对话框触发一次，回到网页后 Win+V 也调不出了。

WPS 里还有个变体：面板粘贴之后，下次按 Ctrl+V 会被识别成 Ctrl+Win+V，复制粘贴整体卡住，约半小时后自行恢复。

## 根因

粘贴模拟的注入序列是 Ctrl down → V down → 8ms → V up → Ctrl up，全程约 10ms。粘贴流程先隐藏主窗口、再执行注入，序列恰好跨过「QC 窗口隐藏 → 前台切回目标窗口」的异步时刻：

- 前段 `Ctrl down` 投递时前台还是 QC 自己的窗口，注入成功，系统逻辑状态表里 Ctrl 记为按下；
- 后段 `Ctrl up` 投递时前台已是高完整性窗口（管理员运行的 3ds Max），被 UIPI 静默丢弃；
- `restore_current_physical` 检测到逻辑与物理状态不一致，补注入 `Ctrl up`，同样被拦截——Ctrl 就永久卡在按下状态。

这一处卡住能解释 issue 里的全部现象：回车变 Ctrl+Enter、方向键变 Ctrl+方向；Win+V 变成 Ctrl+Win+V 后 RegisterHotKey 精确匹配失败，热键自然调不出；管理员模式下注入不被拦截，所以不复现。WPS 场景是恢复逻辑按过期的物理状态重新按下了用户已释放的 Win 键，同一根因的另一种表现。

## 修复

主要改动在 `src-tauri/src/services/paste/keyboard.rs`，面板、快捷键、合并粘贴、便捷粘贴全部路径自动受益。

**注入失败要能感知。** `send_key` / `send_key_ex` 现在检查 `SendInput` 返回值。`Ctrl` / `Shift` 的按下注入失败时立即中止整个序列并记录日志，不给「按下成功、释放被拦」留机会。

**注入前等前台切换完成。** 粘贴前如果本进程窗口刚隐藏（3 秒内埋点有效），先等前台离开这个窗口再注入（上限 300ms），让整个序列落在同一个前台窗口上——要么全部成功、要么全部被拦，不对称没有了。判定很保守：埋点记下需要离开的窗口句柄，只有被隐藏窗口此刻仍持前台、确有一次切换待完成时才等。热键直粘、pin 模式、粘贴目标本来就是本进程窗口（比如文本编辑器）、前台早已落定——这些场景都直接注入，零等待。窗口隐藏后又被用户唤回时，显示路径会清掉埋点，同样不等。还有一种边角：窗口销毁后句柄值被系统复用给了别的进程，此时按进程归属判定切换早已完成，立即放行。

**卡键检测与自愈。** 序列结束后对比 `GetAsyncKeyState` 逻辑状态和 raw_input 物理状态，发现修饰键卡住就补注入释放，并记录日志（含 vk 码）。释放注入还是被拦（前台仍是高完整性窗口）的话，交给前台切换事件回调（`focus.rs` 的 `EVENT_SYSTEM_FOREGROUND` 钩子）重试——用户切回可注入窗口后键盘自动恢复，不轮询、没有时间上限。主键（V/Insert）的 up 被拦同样会卡住逻辑状态（down 已送达、up 被拦），记入 `STUCK_PASTE_KEY` 单槽，由同一个回调在切回后重试释放。raw_input 物理态不可用、自愈链整体失效时，记一条一次性日志。卡键日志按「新出现的卡住状态」去重（位掩码），前台频繁切换时不会刷屏；去重位在释放成功后即清除，同键再次卡住按新状态重新记录。

物理态的起点也补上了：raw_input 的修饰键原子量纯事件驱动，用户在注册前就按住的修饰键（比如开机自启时正按着某个组合键）不会再产生事件，物理态会一直误报为抬起，卡键检测会把用户正按着的键当成卡住、注入一次释放。现在注册成功后、进入消息循环前，先用 `GetAsyncKeyState` 快照把五个原子量的初值校准一遍；校准先于任何事件处理，之后到来的物理事件（包括已经排队的）按序覆盖快照，无论怎么交错终态都正确。

**埋点覆盖所有会引发前台切换的隐藏路径。** 埋点都带上窗口句柄，用来精确判定要不要等：

- 主窗口真隐藏（`visibility.rs`）；
- 低内存面板的主动隐藏与 ESC / 失焦自隐藏（`panel.rs`，经插件 `panel_hwnd()` 取真实句柄；请求时刻和隐藏落地时刻各埋一次，两次方向一致）；
- 进入低占用模式销毁全部 WebView（`manager.rs`，销毁集谓词单点定义，销毁前先比对前台）。

贴边隐藏只是把窗口移出屏幕，不算真隐藏、不引发前台切换，不埋点；便捷粘贴窗口以 `focusable(false)` 创建、从不持有前台，也无需埋点。fltk 侧的隐藏回调以「可见→隐藏」的转换去重（`emit_hidden_once`），无论 fltk 内部重入时机怎么变，每次隐藏都恰好回调一次。

另外，触发键（Win+V 的 V）是用户物理按下的键，物理 up 不受 UIPI 拦截，松手即清除逻辑状态，不存在永久卡键，不需要自愈。

## 验证

按 issue 建议的场景实测：非管理员运行 QC + 管理员运行 3ds Max，在另存为对话框触发粘贴。粘贴本身失败是预期的（UIPI 限制，非提权无法绕过），重点看键盘状态——修复后不再卡死；即便仍出现卡键，切回普通窗口后随前台切换事件自动恢复，不需要结束进程。

P/Invoke 实验直接验证了两个核心机制：注入的修饰键 down 对 `GetAsyncKeyState` 立即可见（卡键检测可靠）；down 成功、up 丢失后卡键状态持续存在，补注入 up 立即恢复（修复手段有效）。另跑了约 11.5 万次并发 SendInput，证实现代 Windows 上「返回 0 是因为被其他线程阻塞」不可达。Tauri 2.11.2 源码静态核对过 `Window::hide` 的派发路径：经主事件循环异步派发，埋点设计对落地时序鲁棒。

`cargo check` 通过，改动文件无新增警告。

## 已知未修复（记录在案）

- restore 双 pass 依赖 raw_input 物理态，而物理态存在毫秒级滞后，极端时序下可能产生约 2ms 的 phantom Win 点按。触发窗口只有毫秒级，较修复前的长时间卡死是净改善；根治要重写状态对齐逻辑，留待后续。
- raw_input 物理态没有新鲜度校验：线程长时间阻塞会让原子量持久过期，可能误抬用户正按着的修饰键；主键自愈重试也有同级的理论误抬窗口。注释在案。
- `wait_away` 仍是裸 `isize`，0 表示前台为空只靠注释区分。
- `entries()` 与 raw_input 五元组的顺序只靠注释对齐，没有编译期保证。
- 隐藏埋点协议散落在 5 个文件多处，埋点与 hide() 的相对顺序契约因 Tauri 异步派发 / fltk 同步而分叉，新增隐藏路径容易漏埋或埋错方向（前台为空时「保守等待」与「销毁前跳过」的差异已按各自时序依据在注释中写明）；`keyboard.rs` 同时承担键盘注入与前台切换跟踪两个职责。收拢成统一的 hide+埋点 helper、拆出前台跟踪模块，留待后续。
- context-menu 粘贴路径没有隐藏埋点：`submit_context_menu` 后 200ms 内 `hide_main_window` 被 `is_context_menu_visible()` 早退，主窗口不隐藏、无埋点，前台切换依赖前端 restoreLastFocus + 50ms sleep 的时序。这是存量行为（基线同样早退），非本 PR 回归，残余竞态有卡键自愈兜底。
- 向高完整性前台粘贴失败（UIPI 固有限制，非提权无法绕过）只记日志、不提示用户（低内存面板粘贴失败是有通知的）——属 UX 改进，留待后续。
- issue 里补充的场景「管理员模式运行时方向键、回车不失效，但剪贴板仍调不出」指向窗口唤起 / 前台激活层，不在注入层（管理员 QC 向管理员窗口注入没有 UIPI 阻拦），与本 PR 的卡键修复正交，待独立诊断。
