### PR TITLE
fix: 面板添加收藏后收藏页不显示新收藏 (#498)

### DIFF
--- a/src/shared/api/clipboard.js
+++ b/src/shared/api/clipboard.js
@@ -185,15 +185,14 @@ export async function addClipboardToFavorites(id, groupName) {
 
   const result = await invoke('add_clipboard_to_favorites', { id, groupName })
   clipboardStore.setFavoriteId(id, result.id)
-  const favoriteItem = await getFavoriteItemById(result.id)
+  // 广播一次数据更新通知即可，收藏列表由事件监听侧重新从数据库读取，
+  // 这里不回读新建收藏，也不直接写收藏分页缓存
   await invoke('emit_quick_texts_updated', {
     payload: {
-      kind: 'created',
-      item: favoriteItem,
-      insert_index: 0,
+      kind: 'updated',
     },
   })
-  return favoriteItem
+  return result
 }
 
 // 另存图片

--- a/src/shared/api/favorites.js
+++ b/src/shared/api/favorites.js
@@ -25,12 +25,11 @@ export async function getFavoritesTotalCount(groupName = null) {
 // 添加收藏
 export async function addFavorite(title, content, groupName = '全部') {
   const result = await invoke('add_quick_text', { title, content, groupName })
-  const item = await invoke('get_favorite_item_by_id_cmd', { id: result.id })
+  // 广播一次数据更新通知即可，收藏列表由事件监听侧重新从数据库读取，
+  // 这里不回读新建收藏，也不直接写收藏分页缓存
   await invoke('emit_quick_texts_updated', {
     payload: {
-      kind: 'created',
-      item,
-      insert_index: 0,
+      kind: 'updated',
     },
   })
   return result

--- a/src/shared/services/eventListener.js
+++ b/src/shared/services/eventListener.js
@@ -1,6 +1,6 @@
 import { listen } from '@tauri-apps/api/event'
 import { refreshClipboardHistory, clipboardStore } from '@shared/store/clipboardStore'
-import { refreshFavorites, favoritesStore } from '@shared/store/favoritesStore'
+import { refreshFavorites } from '@shared/store/favoritesStore'
 import { loadGroups, groupsStore } from '@shared/store/groupsStore'
 import { navigationStore } from '@shared/store/navigationStore'
 
@@ -48,16 +48,6 @@ function shouldRefreshClipboard(payload) {
   )
 }
 
-function shouldRefreshFavorites(payload) {
-  return (
-    favoritesStore.filter ||
-    favoritesStore.contentType !== 'all' ||
-    payload?.kind !== 'created' ||
-    !payload?.item ||
-    !Number.isInteger(payload?.insert_index)
-  )
-}
-
 async function handleClipboardUpdated(payload) {
   try {
     if (shouldRefreshClipboard(payload)) {
@@ -94,39 +84,15 @@ async function handleClipboardUpdated(payload) {
   }
 }
 
-async function handleFavoritesUpdated(payload) {
+// 收藏失效通知：只表达“收藏数据已变化”。统一由现有权威刷新链路
+// 重新读取数据库（refreshFavorites 内部推进请求版本，使更旧的在途
+// 响应失去写回资格），当前分组与筛选由刷新查询携带，事件侧不做
+// 增量插入或分组判断
+async function handleFavoritesUpdated() {
   try {
-    if (payload?.kind === 'created' && payload?.item) {
-      const currentGroup = groupsStore.currentGroup
-      const matchesCurrentGroup =
-        currentGroup === '全部' || !currentGroup || payload.item.group_name === currentGroup
-
-      if (!matchesCurrentGroup) {
-        return
-      }
-    }
-
-    if (shouldRefreshFavorites(payload)) {
-      await refreshFavorites(groupsStore.currentGroup)
-      return
-    }
-
-    const nextTotalCount = favoritesStore.totalCount + 1
-    const inserted = favoritesStore.insertLoadedItemAt(
-      payload.item,
-      payload.insert_index,
-      nextTotalCount,
-    )
-
-    if (!inserted) {
-      await refreshFavorites(groupsStore.currentGroup)
-      return
-    }
-
-    shiftNavigationIndex('favorites', payload.insert_index)
+    await refreshFavorites(groupsStore.currentGroup)
   } catch (error) {
     console.error('处理收藏更新事件失败:', error)
-    await refreshFavorites(groupsStore.currentGroup)
   }
 }
 
@@ -138,8 +104,8 @@ export async function setupClipboardEventListener() {
     })
     unlisteners.push(unlisten1)
 
-    const unlisten2 = await listen('quick-texts-updated', (event) => {
-      handleFavoritesUpdated(event.payload).catch(() => {})
+    const unlisten2 = await listen('quick-texts-updated', () => {
+      handleFavoritesUpdated().catch(() => {})
     })
     unlisteners.push(unlisten2)
 

--- a/src/shared/store/favoritesStore.js
+++ b/src/shared/store/favoritesStore.js
@@ -99,12 +99,7 @@ export const favoritesStore = proxy({
   hasItem(index) {
     return index in this.items
   },
-  
-  // 添加新项到开头（新收藏内容）
-  addItem(item) {
-    this.items = {}
-  },
-  
+
   // 删除项
   removeItem(id) {
     this.removeItems([id])
@@ -200,57 +195,6 @@ export const favoritesStore = proxy({
     return true
   },
 
-  insertLoadedItemAt(item, insertIndex, totalCount) {
-    if (!item || !Number.isInteger(insertIndex) || insertIndex < 0 || insertIndex >= totalCount) {
-      return false
-    }
-
-    const nextItems = {}
-    const entries = Object.entries(this.items)
-      .map(([key, value]) => [parseInt(key, 10), value])
-      .filter(([, value]) => value)
-      .sort((a, b) => b[0] - a[0])
-
-    for (const [index, value] of entries) {
-      const nextIndex = index >= insertIndex ? index + 1 : index
-      if (nextIndex < totalCount) {
-        nextItems[nextIndex] = value
-      }
-    }
-
-    nextItems[insertIndex] = item
-    this.items = nextItems
-    this.totalCount = totalCount
-
-    if (this.selectionAnchorIndex != null && this.selectionAnchorIndex >= insertIndex) {
-      this.selectionAnchorIndex += 1
-    }
-
-    if (this.selectedEntries.length > 0) {
-      this.selectedEntries = this.selectedEntries
-        .map(entry => (
-          entry.index >= insertIndex
-            ? { ...entry, index: entry.index + 1 }
-            : entry
-        ))
-    }
-
-    const { start, end } = this.currentViewRange
-    if (insertIndex <= start) {
-      this.currentViewRange = {
-        start: start + 1,
-        end: end + 1,
-      }
-    } else if (insertIndex <= end) {
-      this.currentViewRange = {
-        start,
-        end: end + 1,
-      }
-    }
-
-    return true
-  },
-  
   setFilter(value) {
     if (this.filter !== value) {
       nextFavoritesRequestVersion()


### PR DESCRIPTION
## 问题

[#498](https://github.com/mosheng1/QuickClipboard/issues/498) 的现象是：收藏页原本为空时，从剪贴板面板添加收藏，数据库已经写入，但回到收藏页还是看不到新条目。

代码里能复现出完整的竞态时序：

1. 收藏页的初始查询还没返回。
2. 用户切到剪贴板页添加收藏，写入成功后触发 `quick-texts-updated`。
3. 原来的事件处理会把新条目直接插进本地缓存，但不会推进收藏请求的版本。
4. 更早发出的空列表响应这时才返回，仍被当作当前请求，把新增条目和总数一起覆盖掉。

这个时序正好对应 #498 里“添加前收藏页为空”的情况，能不能复现取决于两个响应谁先回来。

## 处理方式

这次改动不再让事件侧直接维护收藏分页缓存，`quick-texts-updated` 只当作“数据变了”的信号：

- 收到通知后，按当前分组和筛选条件调用现有的 `refreshFavorites` / `initFavorites`，从数据库重新读一遍。
- `initFavorites` 在发起查询前先推进请求版本；更早发出的响应就算最后才回来，也写不进列表。
- 事件侧的增量插入、分组匹配和导航平移分支一并删掉，`favoritesStore` 里已经没有调用方的收藏插入方法也顺手移除。
- 事件处理里不加定时器兜底，也不直接改 `loading` 或 `loadingRanges`，列表替换只走现有的刷新链路。

收藏创建的两条路径也去掉了写完再查一次的做法：

- 剪贴板面板按 `add → setFavoriteId → invalidate` 的顺序执行，直接用 `add_clipboard_to_favorites` 的返回结果。
- 文本编辑器直接用 `add_quick_text` 的返回结果，再广播一次 `quick-texts-updated`（`kind: 'updated'`，不带条目数据）。
- 两条路径都不再调用 `get_favorite_item_by_id_cmd` 去读刚创建的收藏，也不直接写收藏列表缓存；写命令失败时不发成功通知。

代价是每次写入后会多读一次本地 SQLite，换来的是列表只从数据库刷新这一条路更新，行为好验证。实现仍放在现有的 WebView 状态层，符合 [#502](https://github.com/mosheng1/QuickClipboard/issues/502) 目前优先修稳定性问题的路线。

## 验证

整理提交前用临时行为测试验证过下面这些场景；测试文件和 Vitest 依赖不在这个 PR 里：

- #498 的精确时序：新的刷新先完成，旧的空响应最后返回。
- 多次通知乱序返回时，只保留最新的结果，重复通知不会在本地累加总数或重复插入。
- 当前分组、搜索、内容类型和 `pasteStatus` 都会进正常的刷新查询。
- `clipboard-updated` 原有的增量插入路径保持不变。
- 两条收藏创建路径不再写完再查；剪贴板路径保持 `add → setFavoriteId → invalidate` 的顺序。
- 写命令失败时不更新剪贴板标记，也不发这条通知。

在最终提交上执行过：

- `npm run build`：通过。
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`：38/38 通过。
- `git diff --check fa2eff00...HEAD`：通过。

## 变更范围

整个 PR 只改了 4 个前端生产文件，共 `+17/−109`：

- `src/shared/services/eventListener.js`
- `src/shared/store/favoritesStore.js`
- `src/shared/api/clipboard.js`
- `src/shared/api/favorites.js`

不新增测试框架或依赖，也不动 lockfile、Rust 命令、数据库查询、导航 store、本地化、共享筛选工具和 React 组件。同步收藏 ID 冲突、陈旧 `favorite_id`、重复 LAN 广播、原始格式事务性、收藏页导航保持这些问题继续留在单独的范围里处理，避免把 #498 扩大成一次综合加固。

Closes #498
