### PR TITLE
fix(手绘主题): 修复设置界面下拉框文字下半部分被裁切 (#497)

### DIFF
--- a/src/shared/components/ui/Select.jsx
+++ b/src/shared/components/ui/Select.jsx
@@ -5,10 +5,22 @@ function Select({
   className = '',
   disabled = false
 }) {
-  return <select value={value} onChange={e => onChange(e.target.value)} disabled={disabled} className={`px-3 py-2 bg-qc-panel border border-qc-border rounded-lg text-qc-fg focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer disabled:cursor-not-allowed disabled:opacity-60 ${className}`}>
-      {options.map(option => <option key={option.value} value={option.value}>
-          {option.label}
-        </option>)}
-    </select>;
+  const selectedOption = options.find(option => String(option.value) === String(value)) ?? options[0];
+
+  return <span className={`qc-select ${disabled ? 'qc-select-disabled' : ''} ${className}`}>
+      <select
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        disabled={disabled}
+        className="qc-select-native px-3 py-2 bg-qc-panel border border-qc-border rounded-lg text-qc-fg focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {options.map(option => <option key={option.value} value={option.value}>
+            {option.label}
+          </option>)}
+      </select>
+      <span className="qc-select-display" aria-hidden="true">
+        {selectedOption?.label}
+      </span>
+    </span>;
 }
 export default Select;

--- a/src/shared/styles/index.css
+++ b/src/shared/styles/index.css
@@ -164,3 +164,22 @@ input, select {
   font-size: 14px;
   height: 36px;
 }
+
+.qc-select {
+  display: inline-grid;
+  vertical-align: middle;
+}
+
+.qc-select-native,
+.qc-select-display {
+  grid-area: 1 / 1;
+}
+
+.qc-select-native {
+  width: 100%;
+  min-width: 0;
+}
+
+.qc-select-display {
+  display: none;
+}

--- a/src/shared/styles/wireframe-theme.css
+++ b/src/shared/styles/wireframe-theme.css
@@ -82,6 +82,7 @@ body.theme-light.theme-light-wireframe {
   --wf-grid-v: rgba(0,0,0,0.024);
   --wf-diagonal: rgba(0,0,0,0.03);
   --wf-bg-end: #e7d6bf;
+  --wf-select-arrow: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='13' height='9' viewBox='0 0 13 9'%3E%3Cpath d='M1.5 2 L6.5 7 L11.5 2' fill='none' stroke='%232a1b0c' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
 }
 
 body.theme-dark.theme-dark-sketch {
@@ -169,6 +170,7 @@ body.theme-dark.theme-dark-sketch {
   --wf-grid-v: rgba(255,255,255,0.018);
   --wf-diagonal: rgba(255,255,255,0.024);
   --wf-bg-end: #1a1f27;
+  --wf-select-arrow: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='13' height='9' viewBox='0 0 13 9'%3E%3Cpath d='M1.5 2 L6.5 7 L11.5 2' fill='none' stroke='%23f5f1e8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
 }
 
 body:is(.theme-light.theme-light-wireframe, .theme-dark.theme-dark-sketch),
@@ -221,7 +223,7 @@ body:is(.theme-light.theme-light-wireframe, .theme-dark.theme-dark-sketch) :is(
 
 body:is(.theme-light.theme-light-wireframe, .theme-dark.theme-dark-sketch) :is(
   .main-container, .settings-container, .card, .clipboard-item, .favorite-item,
-  button, input, textarea, select
+  button, input, textarea, select, .qc-select-display
 )::before {
   content: "";
   position: absolute;
@@ -235,7 +237,7 @@ body:is(.theme-light.theme-light-wireframe, .theme-dark.theme-dark-sketch) :is(
 
 body:is(.theme-light.theme-light-wireframe, .theme-dark.theme-dark-sketch) :is(
   .main-container, .settings-container, .card, .clipboard-item, .favorite-item,
-  button, input, textarea, select
+  button, input, textarea, select, .qc-select-display
 )::after {
   content: "";
   position: absolute;
@@ -689,4 +691,56 @@ body:is(.theme-light.theme-light-wireframe, .theme-dark.theme-dark-sketch) hr {
 
 body:is(.theme-light.theme-light-wireframe, .theme-dark.theme-dark-sketch) :is(svg, .icon) {
   filter: contrast(1.08) saturate(0.88) brightness(1.01);
+}
+
+/* WebView2 会裁切原生 select 关闭态的选中值，且该匿名文本盒不受页面行高控制。
+   原生 select 继续负责焦点、键盘和下拉弹层；普通 DOM 显示关闭态文字，
+   因而能完整继承主题首选字体与用户自定义字体。 */
+body:is(.theme-light.theme-light-wireframe, .theme-dark.theme-dark-sketch) .qc-select-native {
+  appearance: none;
+  -webkit-appearance: none;
+  z-index: 2;
+  opacity: 0;
+}
+
+body:is(.theme-light.theme-light-wireframe, .theme-dark.theme-dark-sketch) .qc-select-display {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  height: 36px;
+  padding: 0 32px 0 12px;
+  overflow: hidden;
+  color: var(--qc-fg);
+  line-height: 20px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  border: 2px solid var(--qc-border-strong);
+  border-radius: 12px 5px 10px 6px / 6px 9px 5px 8px;
+  background:
+    var(--wf-select-arrow) right 10px center / 13px 9px no-repeat,
+    linear-gradient(180deg, rgba(255,255,255,0.08), transparent),
+    var(--paper-noise);
+  box-shadow: var(--wf-input-shadow);
+  transition:
+    border-color 0.14s ease,
+    box-shadow 0.14s ease,
+    background 0.14s ease,
+    transform 0.14s ease;
+  isolation: isolate;
+}
+
+body:is(.theme-light.theme-light-wireframe, .theme-dark.theme-dark-sketch) .qc-select:focus-within .qc-select-display {
+  border-color: var(--qc-accent);
+  transform: translate(-1px, -1px);
+  box-shadow:
+    0 0 0 3px rgba(255, 140, 0, 0.16),
+    5px 6px 0 rgba(0,0,0,0.16),
+    10px 11px 0 rgba(0,0,0,0.05);
+}
+
+body:is(.theme-light.theme-light-wireframe, .theme-dark.theme-dark-sketch) .qc-select-disabled .qc-select-display {
+  cursor: not-allowed;
+  opacity: 0.6;
 }


### PR DESCRIPTION
## 问题

手绘风格（亮色 wireframe / 暗色 sketch）下，设置界面的下拉框关闭态文字下半部分会被裁切。

复现路径：设置 → 外观 → 切换为手绘风格 → 音效设置 → 观察「音效播放时机」选择框。

Closes #497

## 根因

Windows WebView2 会在原生 `<select>` 内部的匿名选中值文本盒中排版关闭态文字。即使使用 `appearance: none`，页面 CSS 也无法可靠控制这个内部文本盒的裁切边界；`line-height: 32px` 或改用较小行高配 padding 都只能改变位置，不能恢复被裁掉的字形下缘。

主题虽然把 `ZCOOL KuaiLe` 声明为首选字体，但当前发行包没有加载或内置该字体。Issue 截图和复现环境实际使用系统后备字体，真实打包环境中同样发生裁切，因此 ZCOOL 字体度量不是本问题的根因。

## 修复

- 共享 `Select` 保留真实原生 `<select>`，继续负责焦点、键盘、禁用状态和系统下拉弹层。
- 在手绘主题下仅隐藏原生控件的关闭态绘制，由 `aria-hidden` 的普通 DOM 显示当前选项文字，绕开 WebView2 的匿名文本盒裁切。
- 显示层使用适合 36px 控件的手绘圆角和亮/暗主题箭头；非共享原生 `select` 的外观不变。
- 显示层不指定 `font-family`，继续继承主题首选字体以及用户的全局自定义字体覆盖，不强制系统字体。

## 验证

- 真实 Tauri/WebView2 红灯基线：两个「播放时机」下拉框的可见文字墨迹高度均为 12px，下缘裁切。
- 修复后的 debug 与 release：两处均为 15px，字形下缘完整。
- 原生系统下拉正常展开；键盘切换选项后，普通 DOM 显示层同步更新；测试结束后已恢复原设置。
- `npm run build` 通过。
- Tauri release 可执行文件与 NSIS 安装包成功生成；后续 updater 签名步骤因本机未配置项目私钥而按预期停止。
<img width="900" height="630" alt="image" src="https://github.com/user-attachments/assets/b80882eb-c3c4-46e0-983d-3c8fbb15cc52" />
<img width="900" height="630" alt="image" src="https://github.com/user-attachments/assets/f7a2b87c-c050-4e0a-8233-a69fd12b118d" />

## 范围说明

手绘主题声明 ZCOOL 但发行包未携带该字体是独立问题。本 PR 不引入或修改字体文件，也不改变现有自定义字体机制。
